### PR TITLE
feat: MCP Apps integration — appTool/appResource builders, linter rules, templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ MCP Apps integration — `appTool()` and `appResource()` builders, `_meta` passt
 - **Template: echo app** — `templates/src/mcp-server/tools/definitions/echo-app.app-tool.ts` and `templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts` demonstrate the full MCP Apps pattern for scaffolded servers.
 - **`add-app-tool` skill** — Step-by-step guide for scaffolding MCP App tool + UI resource pairs.
 
+### Fixed
+
+- **`appTool()` clobbered `extraMeta.ui` fields** — The builder overwrote caller-supplied `_meta.ui` sub-fields (e.g. `visibility`) with only `{ resourceUri }`. Now merges `extraMeta.ui` fields with the auto-populated `resourceUri` (which still wins over any `extraMeta.ui.resourceUri`).
+- **Linter false positive on `{+path}` URI templates** — `lintAppToolResourcePairing()` replaced all RFC 6570 expressions with `[^/]+`, causing `{+var}` (reserved expansion) and `{/var}` (path segments) to fail matching URIs containing `/`. Now uses `.+` for slash-expanding operators.
+- **Template echo app missing CSP allowlist** — The scaffolded echo app resource imports `@modelcontextprotocol/ext-apps` from `unpkg.com` but did not declare `_meta.ui.csp.resourceDomains`. Hosts enforcing deny-by-default CSP would block the import. Added `resourceDomains: ['https://unpkg.com']` to the template and skill doc.
+- **CSP field name casing** — Corrected `resource_domains` (snake_case) to `resourceDomains` (camelCase) in JSDoc examples and tests to match the `McpUiResourceCsp` interface from `@modelcontextprotocol/ext-apps`.
+
 ### Tests
 
 - `appBuilders.test.ts` — 414 lines covering `appTool()` and `appResource()` field passthrough, `_meta` population, defaults, and edge cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## [0.3.0] - 2026-04-06
+
+MCP Apps integration — `appTool()` and `appResource()` builders, `_meta` passthrough, linter rules for app tool/resource pairing, template examples, and comprehensive test coverage.
+
+### Added
+
+- **MCP Apps builders** — `appTool()` and `appResource()` convenience builders (`src/mcp-server/apps/appBuilders.ts`). `appTool()` auto-populates `_meta.ui.resourceUri` and the backwards-compat `ui/resourceUri` key. `appResource()` defaults `mimeType` to `text/html;profile=mcp-app` and `annotations.audience` to `['user']`. Both re-exported from the main entry point.
+- **`APP_RESOURCE_MIME_TYPE` constant** — Exported from main entry point, matches `@modelcontextprotocol/ext-apps/server` without requiring the peer dep.
+- **`_meta` passthrough** — `ResourceDefinition` and `TaskToolDefinition` interfaces now accept `_meta`. Tool and resource registration passes `_meta` through to the SDK.
+- **Linter: `_meta.ui` validation** — New rules `meta-ui-type`, `meta-ui-resource-uri-required`, and `meta-ui-resource-uri-scheme` validate tool `_meta.ui` fields at startup.
+- **Linter: app tool ↔ resource pairing** — `lintAppToolResourcePairing()` cross-checks that every tool declaring `_meta.ui.resourceUri` has a matching registered resource. Warns on mismatch. Supports RFC 6570 URI template matching.
+- **Template: echo app** — `templates/src/mcp-server/tools/definitions/echo-app.app-tool.ts` and `templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts` demonstrate the full MCP Apps pattern for scaffolded servers.
+- **`add-app-tool` skill** — Step-by-step guide for scaffolding MCP App tool + UI resource pairs.
+
+### Tests
+
+- `appBuilders.test.ts` — 414 lines covering `appTool()` and `appResource()` field passthrough, `_meta` population, defaults, and edge cases.
+- `tool-rules.test.ts` — 285 lines covering `lintToolDefinition` `_meta.ui` validation and `lintAppToolResourcePairing` cross-check.
+- `validate.test.ts` — +195 lines for `_meta.ui` rules and app tool ↔ resource pairing in the integration linter.
+- `resource-registration.test.ts` — +39 lines for `_meta` passthrough to `server.resource`.
+- `tool-registration.test.ts` — +62 lines for `_meta` passthrough to `server.registerTool` and `registerToolTask`.
+- `mcp-apps.int.test.ts` — 258-line end-to-end integration test covering builder output → linter validation → handler execution → format output.
+- `template-echo-app.app-tool.test.ts` — 115-line smoke test for the echo app tool pattern.
+- `echo-app-ui.app-resource.test.ts` — 95-line smoke test for the echo app UI resource pattern.
+
+### Dependencies
+
+- `dotenv` 17.4.0 → 17.4.1
+- `hono` 4.12.10 → 4.12.11
+- `@cloudflare/workers-types` ^4.20260403.1 → ^4.20260405.1
+- `msw` ^2.12.14 → ^2.13.0
+- `vite` 8.0.3 → 8.0.5
+- `biome.json` schema 2.4.9 → 2.4.10
+
+---
+
 ## [0.2.12] - 2026-04-03
 
 OTel deprecation fix, form-client safety guidance, and dependency updates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Agent Protocol
 
-**Package:** `@cyanheads/mcp-ts-core` · **Version:** 0.2.12
+**Package:** `@cyanheads/mcp-ts-core` · **Version:** 0.3.0
 **npm:** [@cyanheads/mcp-ts-core](https://www.npmjs.com/package/@cyanheads/mcp-ts-core) · **Docker:** [ghcr.io/cyanheads/mcp-ts-core](https://ghcr.io/cyanheads/mcp-ts-core)
 
 > **Developer note:** Never assume. Read related files and docs before making changes. Read full file content for context. Never edit a file before reading it.
@@ -23,7 +23,7 @@
 
 | Subpath | Key Exports | Purpose |
 |:--------|:------------|:--------|
-| `@cyanheads/mcp-ts-core` | `createApp`, `tool`, `resource`, `prompt`, `Context`, `z` | Main entry point |
+| `@cyanheads/mcp-ts-core` | `createApp`, `tool`, `resource`, `prompt`, `appTool`, `appResource`, `APP_RESOURCE_MIME_TYPE`, `Context`, `z` | Main entry point |
 | `/worker` | `createWorkerHandler`, `CloudflareBindings` | Cloudflare Workers entry |
 | `/tools` | `ToolDefinition`, `AnyToolDefinition`, `ToolAnnotations` | Tool definition types |
 | `/resources` | `ResourceDefinition`, `AnyResourceDefinition` | Resource definition types |
@@ -441,6 +441,7 @@ Detailed method signatures, options, and examples live in skill files. Read the 
 | `api-testing` | `skills/api-testing/SKILL.md` | createMockContext, test patterns, MockContextOptions |
 | `api-workers` | `skills/api-workers/SKILL.md` | createWorkerHandler, CloudflareBindings, Worker runtime |
 | `add-tool` | `skills/add-tool/SKILL.md` | Scaffold a new MCP tool definition |
+| `add-app-tool` | `skills/add-app-tool/SKILL.md` | Scaffold an MCP App tool + UI resource pair |
 | `add-resource` | `skills/add-resource/SKILL.md` | Scaffold a new MCP resource definition |
 | `add-prompt` | `skills/add-prompt/SKILL.md` | Scaffold a new MCP prompt definition |
 | `add-service` | `skills/add-service/SKILL.md` | Scaffold a new domain service |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <div align="center">
 
-[![Version](https://img.shields.io/badge/Version-0.2.12-blue.svg?style=flat-square)](./CHANGELOG.md) [![MCP Spec](https://img.shields.io/badge/MCP%20Spec-2025--11--25-8A2BE2.svg?style=flat-square)](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-11-25/changelog.mdx) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE)
+[![Version](https://img.shields.io/badge/Version-0.3.0-blue.svg?style=flat-square)](./CHANGELOG.md) [![MCP Spec](https://img.shields.io/badge/MCP%20Spec-2025--11--25-8A2BE2.svg?style=flat-square)](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-11-25/changelog.mdx) [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-^1.29.0-green.svg?style=flat-square)](https://modelcontextprotocol.io/) [![License](https://img.shields.io/badge/License-Apache%202.0-orange.svg?style=flat-square)](./LICENSE)
 
 [![TypeScript](https://img.shields.io/badge/TypeScript-^6.0.2-3178C6.svg?style=flat-square)](https://www.typescriptlang.org/) [![Bun](https://img.shields.io/badge/Bun-v1.3.2-blueviolet.svg?style=flat-square)](https://bun.sh/)
 
@@ -35,7 +35,7 @@ That's a complete MCP server. Every tool call is automatically logged with durat
 
 ## Features
 
-- **Declarative definitions** — `tool()`, `resource()`, `prompt()` builders with Zod schemas. Framework handles registration, validation, and response formatting.
+- **Declarative definitions** — `tool()`, `resource()`, `prompt()` builders with Zod schemas. `appTool()` and `appResource()` for MCP Apps with interactive HTML UIs. Framework handles registration, validation, and response formatting.
 - **Unified Context** — handlers receive a single `ctx` object with `ctx.log` (request-scoped logging), `ctx.state` (tenant-scoped storage), `ctx.elicit` (user prompting), `ctx.sample` (LLM completion), and `ctx.signal` (cancellation).
 - **Inline auth** — `auth: ['scope']` on definitions. No wrapper functions. Framework checks scopes before calling your handler.
 - **Task tools** — `task: true` flag for long-running operations. Framework manages the full lifecycle (create, poll, progress, complete/fail/cancel).
@@ -162,6 +162,8 @@ See [CLAUDE.md](CLAUDE.md) for the full configuration reference.
 | `tool(name, options)` | Define a tool with `handler(input, ctx)` |
 | `resource(uriTemplate, options)` | Define a resource with `handler(params, ctx)` |
 | `prompt(name, options)` | Define a prompt with `generate(args)` |
+| `appTool(name, options)` | Define an MCP Apps tool with auto-populated `_meta.ui` |
+| `appResource(uriTemplate, options)` | Define an MCP Apps HTML resource with correct MIME type |
 
 ### Context
 
@@ -209,6 +211,7 @@ The `examples/` directory contains a reference server consuming core through pub
 | `template_image_test` | Image content blocks |
 | `template_async_countdown` | `task: true` with `ctx.progress` |
 | `template_data_explorer` | MCP Apps with linked UI resource |
+| `template_echo_app` | MCP Apps with `appTool()`/`appResource()` builders |
 
 ## Testing
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.10",
-        "@cloudflare/workers-types": "^4.20260403.1",
+        "@cloudflare/workers-types": "^4.20260405.1",
         "@hono/otel": "^1.1.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
@@ -46,7 +46,7 @@
         "fast-check": "^4.6.0",
         "ignore": "^7.0.5",
         "js-yaml": "^4.1.1",
-        "msw": "^2.12.14",
+        "msw": "^2.13.0",
         "node-cron": "^4.2.1",
         "openai": "^6.33.0",
         "papaparse": "^5.5.3",
@@ -60,7 +60,7 @@
         "typescript": "^6.0.2",
         "unpdf": "^1.4.0",
         "validator": "^13.15.35",
-        "vite": "8.0.3",
+        "vite": "8.0.5",
         "vitest": "^4.1.2",
       },
       "peerDependencies": {
@@ -122,10 +122,10 @@
     "brace-expansion": "1.1.13",
     "chrono-node": "2.9.0",
     "diff": "8.0.4",
-    "dotenv": "17.4.0",
+    "dotenv": "17.4.1",
     "flatted": "3.4.2",
     "handlebars": "4.7.9",
-    "hono": "4.12.10",
+    "hono": "4.12.11",
     "lodash": "4.18.1",
     "path-to-regexp": "8.4.0",
     "picomatch": "2.3.2",
@@ -187,7 +187,7 @@
 
     "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260403.1", "", {}, "sha512-p6oSNt3yUwcxSoXZ7qCog7+kgQbkSx1Beoci7TMb/xbRF05VR0cO/p1XUE2SLHZ7IgSIc3tNMpFKa0L0fa3Lzg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260405.1", "", {}, "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -621,7 +621,7 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
-    "dotenv": ["dotenv@17.4.0", "", {}, "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="],
+    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -759,7 +759,7 @@
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
 
-    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+    "hono": ["hono@4.12.11", "", {}, "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA=="],
 
     "hono-rate-limiter": ["hono-rate-limiter@0.4.2", "", { "peerDependencies": { "hono": "^4.1.1" } }, "sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw=="],
 
@@ -949,7 +949,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msw": ["msw@2.12.14", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.10.1", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-4KXa4nVBIBjbDbd7vfQNuQ25eFxug0aropCQFoI0JdOBuJWamkT1yLVIWReFI8SiTRc+H1hKzaNk+cLk2N9rtQ=="],
+    "msw": ["msw@2.13.0", "", { "dependencies": { "@inquirer/confirm": "^5.0.0", "@mswjs/interceptors": "^0.41.2", "@open-draft/deferred-promise": "^2.2.0", "@types/statuses": "^2.0.6", "cookie": "^1.0.2", "graphql": "^16.12.0", "headers-polyfill": "^4.0.2", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "path-to-regexp": "^6.3.0", "picocolors": "^1.1.1", "rettime": "^0.10.1", "statuses": "^2.0.2", "strict-event-emitter": "^0.5.1", "tough-cookie": "^6.0.0", "type-fest": "^5.2.0", "until-async": "^3.0.2", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": ">= 4.8.x" }, "optionalPeers": ["typescript"], "bin": { "msw": "cli/index.js" } }, "sha512-5PPWf7I7DBHb4ZUZ0NUI+/VBDk/eiNYDNJZGt/jZ7+rbCSIK5hRcNTGqWMnn0vT6NrHiQlb0nfpenVGz1vrqpg=="],
 
     "multimatch": ["multimatch@5.0.0", "", { "dependencies": { "@types/minimatch": "^3.0.3", "array-differ": "^3.0.0", "array-union": "^2.1.0", "arrify": "^2.0.1", "minimatch": "^3.0.4" } }, "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA=="],
 
@@ -1255,7 +1255,7 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
-    "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
+    "vite": ["vite@8.0.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ=="],
 
     "vitest": ["vitest@4.1.2", "", { "dependencies": { "@vitest/expect": "4.1.2", "@vitest/mocker": "4.1.2", "@vitest/pretty-format": "4.1.2", "@vitest/runner": "4.1.2", "@vitest/snapshot": "4.1.2", "@vitest/spy": "4.1.2", "@vitest/utils": "4.1.2", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.2", "@vitest/browser-preview": "4.1.2", "@vitest/browser-webdriverio": "4.1.2", "@vitest/ui": "4.1.2", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg=="],
 
@@ -1380,6 +1380,8 @@
     "tsc-alias/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "typedoc/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "vitest/vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
     "wrap-ansi/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -1,6 +1,6 @@
 # mcp-ts-core - Directory Structure
 
-Generated on: 2026-03-30 12:35:22
+Generated on: 2026-04-06 15:54:06
 
 ```text
 mcp-ts-core/
@@ -22,21 +22,54 @@ mcp-ts-core/
 ├── claude-plans/
 ├── docs/
 │   ├── mcp-specification/
-│   │   └── 2025-06-18/
-│   │       ├── best-practices/
-│   │       │   └── security.md
+│   │   ├── 2025-06-18/
+│   │   │   ├── best-practices/
+│   │   │   │   └── security.md
+│   │   │   ├── core/
+│   │   │   │   ├── authorization.md
+│   │   │   │   ├── lifecycle.md
+│   │   │   │   ├── overview.md
+│   │   │   │   └── transports.md
+│   │   │   └── utils/
+│   │   │       ├── cancellation.md
+│   │   │       ├── completion.md
+│   │   │       ├── logging.md
+│   │   │       ├── pagination.md
+│   │   │       ├── ping.md
+│   │   │       └── progress.md
+│   │   └── 2025-11-25/
+│   │       ├── client/
+│   │       │   ├── elicitation.md
+│   │       │   ├── roots.md
+│   │       │   └── sampling.md
 │   │       ├── core/
 │   │       │   ├── authorization.md
 │   │       │   ├── lifecycle.md
 │   │       │   ├── overview.md
 │   │       │   └── transports.md
-│   │       └── utils/
-│   │           ├── cancellation.md
-│   │           ├── completion.md
-│   │           ├── logging.md
-│   │           ├── pagination.md
-│   │           ├── ping.md
-│   │           └── progress.md
+│   │       ├── extensions/
+│   │       │   ├── apps-build.md
+│   │       │   ├── apps-overview.md
+│   │       │   ├── auth-enterprise-managed.md
+│   │       │   ├── auth-oauth-client-credentials.md
+│   │       │   ├── auth-overview.md
+│   │       │   ├── client-matrix.md
+│   │       │   └── overview.md
+│   │       ├── server/
+│   │       │   ├── overview.md
+│   │       │   ├── prompts.md
+│   │       │   ├── resources.md
+│   │       │   ├── tools.md
+│   │       │   └── utilities.md
+│   │       ├── utils/
+│   │       │   ├── cancellation.md
+│   │       │   ├── ping.md
+│   │       │   ├── progress.md
+│   │       │   └── tasks.md
+│   │       ├── architecture.md
+│   │       ├── key-changes.md
+│   │       ├── schema-reference.md
+│   │       └── specification.md
 │   ├── conformance-test-plan.md
 │   └── resource-notifications.md
 ├── examples/
@@ -70,6 +103,8 @@ mcp-ts-core/
 │   ├── tree.ts
 │   └── update-coverage.ts
 ├── skills/
+│   ├── add-app-tool/
+│   │   └── SKILL.md
 │   ├── add-export/
 │   │   └── SKILL.md
 │   ├── add-prompt/
@@ -159,6 +194,8 @@ mcp-ts-core/
 │   │   ├── types.ts
 │   │   └── validate.ts
 │   ├── mcp-server/
+│   │   ├── apps/
+│   │   │   └── appBuilders.ts
 │   │   ├── prompts/
 │   │   │   ├── utils/
 │   │   │   │   └── promptDefinition.ts
@@ -328,9 +365,11 @@ mcp-ts-core/
 │   │   │   │       └── echo.prompt.ts
 │   │   │   ├── resources/
 │   │   │   │   └── definitions/
+│   │   │   │       ├── echo-app-ui.app-resource.ts
 │   │   │   │       └── echo.resource.ts
 │   │   │   └── tools/
 │   │   │       └── definitions/
+│   │   │           ├── echo-app.app-tool.ts
 │   │   │           └── echo.tool.ts
 │   │   └── index.ts
 │   ├── tests/
@@ -384,11 +423,13 @@ mcp-ts-core/
 │   │   ├── prompts/
 │   │   │   └── code-review.prompt.test.ts
 │   │   ├── resources/
+│   │   │   ├── echo-app-ui.app-resource.test.ts
 │   │   │   └── echo.resource.test.ts
 │   │   └── tools/
 │   │       ├── template-async-countdown.tool.test.ts
 │   │       ├── template-code-review-sampling.tool.test.ts
 │   │       ├── template-data-explorer.app-tool.test.ts
+│   │       ├── template-echo-app.app-tool.test.ts
 │   │       ├── template-echo-message.tool.test.ts
 │   │       └── template-madlibs-elicitation.tool.test.ts
 │   ├── unit/
@@ -399,8 +440,11 @@ mcp-ts-core/
 │   │   ├── core/
 │   │   │   └── app.test.ts
 │   │   ├── linter/
+│   │   │   ├── tool-rules.test.ts
 │   │   │   └── validate.test.ts
 │   │   ├── mcp-server/
+│   │   │   ├── apps/
+│   │   │   │   └── appBuilders.test.ts
 │   │   │   ├── prompts/
 │   │   │   │   ├── utils/
 │   │   │   │   │   └── promptDefinition.test.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cyanheads/mcp-ts-core",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "mcpName": "io.github.cyanheads/mcp-ts-core",
   "description": "Agent-native TypeScript framework for building MCP servers. Build tools, not infrastructure. Declarative definitions with auth, multi-backend storage, OpenTelemetry, and first-class support for Node.js and Cloudflare Workers.",
   "main": "dist/core/index.js",
@@ -144,11 +144,11 @@
     "@hono/node-server": "1.19.12",
     "chrono-node": "2.9.0",
     "diff": "8.0.4",
-    "dotenv": "17.4.0",
+    "dotenv": "17.4.1",
     "brace-expansion": "1.1.13",
     "flatted": "3.4.2",
     "handlebars": "4.7.9",
-    "hono": "4.12.10",
+    "hono": "4.12.11",
     "lodash": "4.18.1",
     "path-to-regexp": "8.4.0",
     "picomatch": "2.3.2",
@@ -157,7 +157,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
-    "@cloudflare/workers-types": "^4.20260403.1",
+    "@cloudflare/workers-types": "^4.20260405.1",
     "@hono/otel": "^1.1.1",
     "@opentelemetry/instrumentation-http": "^0.214.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
@@ -186,7 +186,7 @@
     "fast-check": "^4.6.0",
     "js-yaml": "^4.1.1",
     "ignore": "^7.0.5",
-    "msw": "^2.12.14",
+    "msw": "^2.13.0",
     "node-cron": "^4.2.1",
     "openai": "^6.33.0",
     "papaparse": "^5.5.3",
@@ -200,7 +200,7 @@
     "typescript": "^6.0.2",
     "unpdf": "^1.4.0",
     "validator": "^13.15.35",
-    "vite": "8.0.3",
+    "vite": "8.0.5",
     "vitest": "^4.1.2"
   },
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -6,14 +6,14 @@
     "url": "https://github.com/cyanheads/mcp-ts-core",
     "source": "github"
   },
-  "version": "0.2.12",
+  "version": "0.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/mcp-ts-core",
       "runtimeHint": "bun",
-      "version": "0.2.12",
+      "version": "0.3.0",
       "packageArguments": [
         {
           "type": "positional",
@@ -42,7 +42,7 @@
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cyanheads/mcp-ts-core",
       "runtimeHint": "bun",
-      "version": "0.2.12",
+      "version": "0.3.0",
       "packageArguments": [
         {
           "type": "positional",

--- a/skills/add-app-tool/SKILL.md
+++ b/skills/add-app-tool/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: add-app-tool
+description: >
+  Scaffold an MCP App tool + UI resource pair. Use when the user asks to add a tool with interactive UI, create an MCP App, or build a visual/interactive tool.
+metadata:
+  author: cyanheads
+  version: "1.0"
+  audience: external
+  type: reference
+---
+
+## Context
+
+MCP Apps extend the standard tool pattern with an interactive HTML UI rendered in a sandboxed iframe by the host. Each MCP App consists of two definitions:
+
+1. **App tool** (`.app-tool.ts`) — uses `appTool()` builder, declares `resourceUri` pointing to the UI resource
+2. **App resource** (`.app-resource.ts`) — uses `appResource()` builder, serves the bundled HTML
+
+Both builders are exported from `@cyanheads/mcp-ts-core`. They handle `_meta.ui.resourceUri`, the compat key (`ui/resourceUri`), and the correct MIME type (`text/html;profile=mcp-app`) automatically.
+
+For the full API, Context interface, and error codes, read:
+
+    node_modules/@cyanheads/mcp-ts-core/CLAUDE.md
+
+## Steps
+
+1. **Ask the user** for the tool's name, purpose, input/output shape, and what the UI should display
+2. **Choose a URI** — convention: `ui://{{tool-name}}/app.html`
+3. **Create the app tool** at `src/mcp-server/tools/definitions/{{tool-name}}.app-tool.ts`
+4. **Create the app resource** at `src/mcp-server/resources/definitions/{{tool-name}}-ui.app-resource.ts`
+5. **Register both** in their respective `definitions/index.ts` barrels
+6. **Run `bun run devcheck`** — the linter validates `_meta.ui` and cross-checks tool/resource pairing
+7. **Smoke-test** with `bun run dev:stdio` or `dev:http`
+
+## App Tool Template
+
+```typescript
+/**
+ * @fileoverview {{TOOL_DESCRIPTION}}
+ * @module mcp-server/tools/definitions/{{TOOL_NAME}}.app-tool
+ */
+
+import { appTool, z } from '@cyanheads/mcp-ts-core';
+
+const UI_RESOURCE_URI = 'ui://{{tool-name}}/app.html';
+
+export const {{TOOL_EXPORT}} = appTool('{{tool_name}}', {
+  resourceUri: UI_RESOURCE_URI,
+  title: '{{TOOL_TITLE}}',
+  description: '{{TOOL_DESCRIPTION}}',
+  annotations: { readOnlyHint: true },
+  input: z.object({
+    // All fields need .describe(). Only JSON-Schema-serializable Zod types allowed.
+  }),
+  output: z.object({
+    // All fields need .describe(). Only JSON-Schema-serializable Zod types allowed.
+  }),
+  // auth: ['tool:{{tool_name}}:read'],
+
+  async handler(input, ctx) {
+    ctx.log.info('Processing', { /* relevant input fields */ });
+    return { /* output */ };
+  },
+
+  // format() serves dual purpose for app tools:
+  // 1. First text block: JSON for the UI (app.ontoolresult parses it)
+  // 2. Subsequent blocks: human-readable fallback for non-app hosts and LLM context
+  format(result) {
+    return [
+      { type: 'text', text: JSON.stringify(result) },
+      { type: 'text', text: '/* human-readable summary */' },
+    ];
+  },
+});
+```
+
+## App Resource Template
+
+```typescript
+/**
+ * @fileoverview UI resource for {{TOOL_NAME}}.
+ * @module mcp-server/resources/definitions/{{TOOL_NAME}}-ui.app-resource
+ */
+
+import { appResource, z } from '@cyanheads/mcp-ts-core';
+
+const ParamsSchema = z.object({}).describe('No parameters. Returns the static HTML app.');
+
+const APP_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{TOOL_TITLE}}</title>
+  <style>/* your styles */</style>
+</head>
+<body>
+  <!-- your UI markup -->
+
+  <script type="module">
+    import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@1/app-with-deps";
+
+    const app = new App({ name: "{{TOOL_TITLE}}", version: "1.0.0" });
+
+    // Receive initial tool result from the host
+    app.ontoolresult = (result) => {
+      const text = result.content?.find(c => c.type === "text")?.text;
+      if (!text) return;
+      const data = JSON.parse(text);
+      // render data into the DOM
+    };
+
+    // Proactively call tools from the UI
+    document.getElementById("action-btn").addEventListener("click", async () => {
+      const result = await app.callServerTool({
+        name: "{{tool_name}}",
+        arguments: { /* input */ },
+      });
+      // handle result
+    });
+
+    await app.connect();
+  </script>
+</body>
+</html>`;
+
+export const {{RESOURCE_EXPORT}} = appResource('ui://{{tool-name}}/app.html', {
+  name: '{{tool-name}}-ui',
+  title: '{{TOOL_TITLE}} UI',
+  description: 'Interactive HTML app for {{tool_name}}.',
+  params: ParamsSchema,
+  // auth: ['resource:{{tool-name}}-ui:read'],
+
+  handler(_params, ctx) {
+    ctx.log.debug('Serving app UI.', { resourceUri: ctx.uri?.href });
+    return APP_HTML;
+  },
+
+  list: () => ({
+    resources: [
+      {
+        uri: 'ui://{{tool-name}}/app.html',
+        name: '{{TOOL_TITLE}}',
+        description: 'Interactive UI for {{tool_name}}.',
+      },
+    ],
+  }),
+});
+```
+
+## UI Design Notes
+
+- **Bundling:** The simplest approach is inlining HTML/CSS/JS as a template literal (shown above). For complex UIs, use Vite + `vite-plugin-singlefile` to bundle into a single HTML file and read it from disk in the handler.
+- **Client-side SDK:** Import `App` from `@modelcontextprotocol/ext-apps` via CDN or bundle it. The `App` class provides `connect()`, `ontoolresult`, `callServerTool()`, `sendMessage()`, and `sendOpenLink()`.
+- **CSP:** Inline scripts and styles work by default. External resources need CSP configuration via `_meta.ui.csp` on the resource content items (in `format()`) or on the resource definition's `_meta`.
+- **format() for app tools:** The first `text` content block is typically JSON that the UI parses via `ontoolresult`. Additional blocks provide a human-readable fallback that non-app hosts and LLMs consume.
+
+## Barrel Registration
+
+```typescript
+// src/mcp-server/tools/definitions/index.ts
+import { {{TOOL_EXPORT}} } from './{{tool-name}}.app-tool.js';
+
+export const allToolDefinitions = [
+  // ... existing tools,
+  {{TOOL_EXPORT}},
+];
+
+// src/mcp-server/resources/definitions/index.ts
+import { {{RESOURCE_EXPORT}} } from './{{tool-name}}-ui.app-resource.js';
+
+export const allResourceDefinitions = [
+  // ... existing resources,
+  {{RESOURCE_EXPORT}},
+];
+```
+
+## Checklist
+
+- [ ] App tool created at `src/mcp-server/tools/definitions/{{tool-name}}.app-tool.ts` using `appTool()`
+- [ ] App resource created at `src/mcp-server/resources/definitions/{{tool-name}}-ui.app-resource.ts` using `appResource()`
+- [ ] `resourceUri` matches between tool and resource (`ui://{{tool-name}}/app.html`)
+- [ ] Zod schemas: all fields have `.describe()`, only JSON-Schema-serializable types
+- [ ] `format()` renders JSON first block (for UI) + human-readable blocks (for non-app hosts)
+- [ ] UI calls `app.connect()` and handles `app.ontoolresult`
+- [ ] Both registered in their respective `definitions/index.ts` barrels
+- [ ] `bun run devcheck` passes (linter validates `_meta.ui` and tool/resource pairing)
+- [ ] Smoke-tested with `bun run dev:stdio` or `dev:http`

--- a/skills/add-app-tool/SKILL.md
+++ b/skills/add-app-tool/SKILL.md
@@ -128,6 +128,12 @@ export const {{RESOURCE_EXPORT}} = appResource('ui://{{tool-name}}/app.html', {
   name: '{{tool-name}}-ui',
   title: '{{TOOL_TITLE}} UI',
   description: 'Interactive HTML app for {{tool_name}}.',
+  // CSP allowlist for external CDN imports (MCP Apps iframes use deny-by-default CSP)
+  _meta: {
+    ui: {
+      csp: { resourceDomains: ['https://unpkg.com'] },
+    },
+  },
   params: ParamsSchema,
   // auth: ['resource:{{tool-name}}-ui:read'],
 
@@ -152,7 +158,7 @@ export const {{RESOURCE_EXPORT}} = appResource('ui://{{tool-name}}/app.html', {
 
 - **Bundling:** The simplest approach is inlining HTML/CSS/JS as a template literal (shown above). For complex UIs, use Vite + `vite-plugin-singlefile` to bundle into a single HTML file and read it from disk in the handler.
 - **Client-side SDK:** Import `App` from `@modelcontextprotocol/ext-apps` via CDN or bundle it. The `App` class provides `connect()`, `ontoolresult`, `callServerTool()`, `sendMessage()`, and `sendOpenLink()`.
-- **CSP:** Inline scripts and styles work by default. External resources need CSP configuration via `_meta.ui.csp` on the resource content items (in `format()`) or on the resource definition's `_meta`.
+- **CSP:** MCP Apps iframes run under deny-by-default CSP. Inline scripts and styles work by default. External resources (CDN imports, API endpoints) require `_meta.ui.csp.resourceDomains` on the resource definition — e.g., `_meta: { ui: { csp: { resourceDomains: ['https://unpkg.com'] } } }`. Without this, hosts that enforce CSP will block the import and the app will not boot.
 - **format() for app tools:** The first `text` content block is typically JSON that the UI parses via `ontoolresult`. Additional blocks provide a human-readable fallback that non-app hosts and LLMs consume.
 
 ## Barrel Registration

--- a/skills/design-mcp-server/SKILL.md
+++ b/skills/design-mcp-server/SKILL.md
@@ -74,6 +74,7 @@ This is the raw material. Not everything becomes a tool.
 | Primitive | Use when | Examples |
 |:----------|:---------|:--------|
 | **Tool** | The default. Any operation or data access an agent needs to accomplish the server's purpose. | Search, create, update, analyze, fetch-by-ID, list reference data |
+| **App Tool** | Tool whose results benefit from interactive HTML UI (data visualization, forms, rich rendering). Uses `appTool()` + paired `appResource()`. Hosts without MCP Apps support receive the text fallback from `format()`. | Dashboards, data explorers, interactive charts, form-based workflows |
 | **Resource** | *Additionally* expose as a resource when the data is addressable by stable URI, read-only, and useful as injectable context. | Config, schemas, status, entity-by-ID lookups |
 | **Prompt** | Reusable message template that structures how the LLM approaches a task | Analysis framework, report template, review checklist |
 | **Neither** | Internal detail, admin-only, not useful to an LLM | Token refresh, webhook setup, migrations |
@@ -419,10 +420,11 @@ If the user has already authorized implementation (e.g., "build me a ___ server"
 Execute the plan using the scaffolding skills:
 
 1. `add-service` for each service
-2. `add-tool` for each tool
-3. `add-resource` for each resource
-4. `add-prompt` for each prompt
-5. `devcheck` after each addition
+2. `add-tool` for each standard tool
+3. `add-app-tool` for each MCP Apps tool (creates paired tool + UI resource)
+4. `add-resource` for each standalone resource
+5. `add-prompt` for each prompt
+6. `devcheck` after each addition
 
 ## Checklist
 
@@ -438,6 +440,7 @@ Execute the plan using the scaffolding skills:
 - [ ] Error messages guide recovery — name what went wrong and what to do next
 - [ ] Annotations set correctly (`readOnlyHint`, `destructiveHint`, etc.)
 - [ ] Tool surface is self-sufficient — a tool-only agent can accomplish everything the server is for
+- [ ] MCP Apps tools identified where interactive UI adds value (and `format()` provides full text fallback for non-app hosts)
 - [ ] Resource URIs use `{param}` templates, pagination planned for large lists
 - [ ] Service layer planned (or explicitly skipped with reasoning)
 - [ ] Resilience planned for external API services (retry boundary, backoff, parse classification)

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,6 +36,7 @@ export type {
 // Definition builders & types
 // ---------------------------------------------------------------------------
 
+export { APP_RESOURCE_MIME_TYPE, appResource, appTool } from '@/mcp-server/apps/appBuilders.js';
 export type {
   AnyPromptDefinition,
   PromptDefinition,
@@ -45,7 +46,6 @@ export type {
   AnyResourceDefinition,
   ResourceDefinition,
 } from '@/mcp-server/resources/utils/resourceDefinition.js';
-
 export { resource } from '@/mcp-server/resources/utils/resourceDefinition.js';
 /** Union of all accepted tool definition shapes (standard + task). */
 export type { AnyToolDef } from '@/mcp-server/tools/tool-registration.js';

--- a/src/linter/rules/index.ts
+++ b/src/linter/rules/index.ts
@@ -12,4 +12,4 @@ export {
   checkSchemaSerializable,
 } from './schema-rules.js';
 export { lintServerJson } from './server-json-rules.js';
-export { lintAuthScopes, lintToolDefinition } from './tool-rules.js';
+export { lintAppToolResourcePairing, lintAuthScopes, lintToolDefinition } from './tool-rules.js';

--- a/src/linter/rules/tool-rules.ts
+++ b/src/linter/rules/tool-rules.ts
@@ -230,17 +230,25 @@ export function lintAppToolResourcePairing(
 
 /**
  * Converts an RFC 6570 URI template to a regex that matches concrete URIs.
- * Replaces `{var}` (with optional operators) with `[^/]+` for simple matching.
- * This is intentionally permissive — lint-time, not runtime routing.
+ * Respects operators: `{+var}` (reserved) and `{/var}` (path segments) can
+ * expand to values containing `/`, so they match `.+`. All other expressions
+ * match `[^/]+`. Intentionally permissive — lint-time, not runtime routing.
  */
 function uriTemplateToRegex(template: string): RegExp {
-  const escaped = template.replace(/[.*+?^${}()|[\]\\]/g, (ch) => {
-    // Don't escape { and } — we replace template expressions below
-    if (ch === '{' || ch === '}') return ch;
-    return `\\${ch}`;
-  });
-  // Replace {+var}, {#var}, {?var,var2}, {var}, etc. with a permissive segment match
-  const pattern = escaped.replace(/\{[^}]+\}/g, '[^/]+');
+  // Split on template expressions first, then escape only the literal parts.
+  // This avoids escaping operator characters (e.g. +) inside expressions.
+  const parts = template.split(/(\{[^}]+\})/);
+  let pattern = '';
+  for (const part of parts) {
+    if (part.startsWith('{') && part.endsWith('}')) {
+      const expr = part.slice(1, -1);
+      const op = expr.charAt(0);
+      // {+var} (reserved) and {/var} (path segments) can expand to values with slashes
+      pattern += op === '+' || op === '/' ? '.+' : '[^/]+';
+    } else {
+      pattern += part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
   return new RegExp(`^${pattern}$`);
 }
 

--- a/src/linter/rules/tool-rules.ts
+++ b/src/linter/rules/tool-rules.ts
@@ -83,6 +83,11 @@ export function lintToolDefinition(def: unknown): LintDiagnostic[] {
     diagnostics.push(...lintToolAnnotations(d.annotations as Record<string, unknown>, name));
   }
 
+  // _meta.ui validation (MCP Apps)
+  if (d?._meta && typeof d._meta === 'object') {
+    diagnostics.push(...lintToolMeta(d._meta as Record<string, unknown>, displayName));
+  }
+
   return diagnostics;
 }
 
@@ -121,6 +126,122 @@ export function lintAuthScopes(
   }
 
   return diagnostics;
+}
+
+/** Validates `_meta.ui` fields for MCP Apps tools. */
+function lintToolMeta(meta: Record<string, unknown>, toolName: string): LintDiagnostic[] {
+  const diagnostics: LintDiagnostic[] = [];
+  const ui = meta.ui;
+
+  if (ui === undefined) return diagnostics;
+
+  if (typeof ui !== 'object' || ui === null) {
+    diagnostics.push({
+      rule: 'meta-ui-type',
+      severity: 'error',
+      message: `Tool '${toolName}' _meta.ui must be an object.`,
+      definitionType: 'tool',
+      definitionName: toolName,
+    });
+    return diagnostics;
+  }
+
+  const uiObj = ui as Record<string, unknown>;
+
+  // resourceUri is required when _meta.ui is present
+  if (typeof uiObj.resourceUri !== 'string' || uiObj.resourceUri.length === 0) {
+    diagnostics.push({
+      rule: 'meta-ui-resource-uri-required',
+      severity: 'error',
+      message:
+        `Tool '${toolName}' _meta.ui is present but missing a valid resourceUri string. ` +
+        'MCP Apps tools must declare _meta.ui.resourceUri pointing to a ui:// resource.',
+      definitionType: 'tool',
+      definitionName: toolName,
+    });
+  } else if (!uiObj.resourceUri.startsWith('ui://')) {
+    diagnostics.push({
+      rule: 'meta-ui-resource-uri-scheme',
+      severity: 'warning',
+      message:
+        `Tool '${toolName}' _meta.ui.resourceUri '${uiObj.resourceUri}' does not use the ui:// scheme. ` +
+        'MCP Apps resources conventionally use the ui:// scheme.',
+      definitionType: 'tool',
+      definitionName: toolName,
+    });
+  }
+
+  return diagnostics;
+}
+
+/**
+ * Cross-definition check: verifies that every tool declaring `_meta.ui.resourceUri`
+ * has a matching resource registered with that URI template.
+ */
+export function lintAppToolResourcePairing(
+  tools: unknown[],
+  resources: unknown[],
+): LintDiagnostic[] {
+  const diagnostics: LintDiagnostic[] = [];
+
+  // Collect registered resource URI templates and compile matchers.
+  // Templates may contain RFC 6570 variables (e.g. ui://app/{page}) that need
+  // to match concrete URIs from tool _meta.ui.resourceUri (e.g. ui://app/dashboard).
+  const resourceTemplates: string[] = [];
+  const resourceMatchers: RegExp[] = [];
+  for (const r of resources) {
+    const rd = r as Record<string, unknown>;
+    if (typeof rd?.uriTemplate === 'string') {
+      resourceTemplates.push(rd.uriTemplate);
+      resourceMatchers.push(uriTemplateToRegex(rd.uriTemplate));
+    }
+  }
+
+  // Check each app tool's resourceUri against registered resources
+  for (const t of tools) {
+    const td = t as Record<string, unknown>;
+    const meta = td?._meta as Record<string, unknown> | undefined;
+    const ui = meta?.ui as Record<string, unknown> | undefined;
+    const resourceUri = ui?.resourceUri;
+    if (typeof resourceUri !== 'string') continue;
+
+    const toolName = typeof td.name === 'string' ? td.name : '<unnamed>';
+    const matched = resourceMatchers.some((re) => re.test(resourceUri));
+
+    if (!matched) {
+      const registered =
+        resourceTemplates.length > 0
+          ? ` Registered resource templates: ${resourceTemplates.join(', ')}`
+          : ' No resources are registered.';
+      diagnostics.push({
+        rule: 'app-tool-resource-pairing',
+        severity: 'warning',
+        message:
+          `Tool '${toolName}' declares _meta.ui.resourceUri '${resourceUri}' but no resource ` +
+          `with a matching URI template is registered. The host will fail to fetch the app UI at runtime.${registered}`,
+        definitionType: 'tool',
+        definitionName: toolName,
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+/**
+ * Converts an RFC 6570 URI template to a regex that matches concrete URIs.
+ * Replaces `{var}` (with optional operators) with `[^/]+` for simple matching.
+ * This is intentionally permissive — lint-time, not runtime routing.
+ */
+function uriTemplateToRegex(template: string): RegExp {
+  const escaped = template.replace(/[.*+?^${}()|[\]\\]/g, (ch) => {
+    // Don't escape { and } — we replace template expressions below
+    if (ch === '{' || ch === '}') return ch;
+    return `\\${ch}`;
+  });
+  // Replace {+var}, {#var}, {?var,var2}, {var}, etc. with a permissive segment match
+  const pattern = escaped.replace(/\{[^}]+\}/g, '[^/]+');
+  return new RegExp(`^${pattern}$`);
 }
 
 /** Validates that annotation hint values are booleans where expected. */

--- a/src/linter/validate.ts
+++ b/src/linter/validate.ts
@@ -9,7 +9,7 @@ import { checkDuplicateNames } from './rules/name-rules.js';
 import { lintPromptDefinition } from './rules/prompt-rules.js';
 import { lintResourceDefinition } from './rules/resource-rules.js';
 import { lintServerJson } from './rules/server-json-rules.js';
-import { lintToolDefinition } from './rules/tool-rules.js';
+import { lintAppToolResourcePairing, lintToolDefinition } from './rules/tool-rules.js';
 import type { LintDiagnostic, LintInput, LintReport } from './types.js';
 
 /**
@@ -84,6 +84,9 @@ export function validateDefinitions(input: LintInput): LintReport {
   diagnostics.push(...checkDuplicateNames(resourceNames, 'resource'));
 
   diagnostics.push(...checkDuplicateNames(extractNames(prompts), 'prompt'));
+
+  // Cross-definition: app tool ↔ app resource pairing
+  diagnostics.push(...lintAppToolResourcePairing(tools, resources));
 
   const errors = diagnostics.filter((d) => d.severity === 'error');
   const warnings = diagnostics.filter((d) => d.severity === 'warning');

--- a/src/mcp-server/apps/appBuilders.ts
+++ b/src/mcp-server/apps/appBuilders.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Convenience builders for MCP Apps — `appTool()` and `appResource()`.
+ * Wraps the standard `tool()` and `resource()` builders with MCP Apps-specific
+ * defaults: auto-populates `_meta.ui.resourceUri`, sets the correct MIME type,
+ * and handles the compat key (`ui/resourceUri`) required by some hosts.
+ * @module src/mcp-server/apps/appBuilders
+ */
+
+import type { ZodObject, ZodRawShape } from 'zod';
+
+import type { ResourceDefinition } from '@/mcp-server/resources/utils/resourceDefinition.js';
+import { resource } from '@/mcp-server/resources/utils/resourceDefinition.js';
+import type { ToolDefinition } from '@/mcp-server/tools/utils/toolDefinition.js';
+import { tool } from '@/mcp-server/tools/utils/toolDefinition.js';
+
+/**
+ * MIME type for MCP Apps HTML resources.
+ * Matches `RESOURCE_MIME_TYPE` from `@modelcontextprotocol/ext-apps/server`
+ * so consumers don't need the peer dependency for this constant alone.
+ */
+export const APP_RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
+
+/**
+ * Backwards-compat metadata key required by some MCP hosts.
+ * Matches `RESOURCE_URI_META_KEY` from `@modelcontextprotocol/ext-apps/server`.
+ */
+const RESOURCE_URI_META_KEY = 'ui/resourceUri';
+
+// ---------------------------------------------------------------------------
+// appTool()
+// ---------------------------------------------------------------------------
+
+/** Options for `appTool()` — extends standard tool options with the UI resource URI. */
+type AppToolOptions<
+  TInput extends ZodObject<ZodRawShape>,
+  TOutput extends ZodObject<ZodRawShape>,
+> = Omit<ToolDefinition<TInput, TOutput>, '_meta' | 'name'> & {
+  /**
+   * Additional `_meta` fields beyond the auto-populated `ui` and compat key.
+   * Merged with the generated `_meta.ui` — do not set `ui` or `ui/resourceUri` here.
+   */
+  extraMeta?: Record<string, unknown>;
+  /** URI of the `ui://` resource that hosts will fetch and render as a sandboxed iframe. */
+  resourceUri: string;
+};
+
+/**
+ * Creates an MCP Apps tool definition. Wraps `tool()` with:
+ * - `_meta.ui.resourceUri` set automatically
+ * - `_meta['ui/resourceUri']` compat key set automatically
+ *
+ * @example
+ * ```ts
+ * import { appTool, z } from '@cyanheads/mcp-ts-core';
+ *
+ * export const myAppTool = appTool('my_app_tool', {
+ *   resourceUri: 'ui://my-app/app.html',
+ *   description: 'Interactive widget.',
+ *   input: z.object({ query: z.string().describe('Search query') }),
+ *   output: z.object({ items: z.array(z.string()).describe('Results') }),
+ *   handler(input, ctx) { return { items: ['a', 'b'] }; },
+ * });
+ * ```
+ */
+export function appTool<
+  TInput extends ZodObject<ZodRawShape>,
+  TOutput extends ZodObject<ZodRawShape>,
+>(name: string, options: AppToolOptions<TInput, TOutput>): ToolDefinition<TInput, TOutput> {
+  const { resourceUri, extraMeta, ...rest } = options;
+
+  return tool(name, {
+    ...rest,
+    _meta: {
+      ...extraMeta,
+      ui: { resourceUri },
+      [RESOURCE_URI_META_KEY]: resourceUri,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// appResource()
+// ---------------------------------------------------------------------------
+
+/** Options for `appResource()` — standard resource options with app-specific defaults. */
+type AppResourceOptions<
+  TParams extends ZodObject<ZodRawShape>,
+  TOutput extends ZodObject<ZodRawShape> | undefined = undefined,
+> = Omit<ResourceDefinition<TParams, TOutput>, 'mimeType' | 'uriTemplate'> & {
+  /** Override the default `text/html;profile=mcp-app` MIME type. Rarely needed. */
+  mimeType?: string;
+};
+
+/**
+ * Creates an MCP Apps resource definition. Wraps `resource()` with:
+ * - `mimeType` defaulting to `text/html;profile=mcp-app`
+ * - `annotations.audience` defaulting to `['user']`
+ *
+ * The `uriTemplate` should use the `ui://` scheme.
+ *
+ * @example
+ * ```ts
+ * import { appResource, z } from '@cyanheads/mcp-ts-core';
+ *
+ * export const myAppResource = appResource('ui://my-app/app.html', {
+ *   name: 'my-app-ui',
+ *   description: 'Interactive UI for my_app_tool.',
+ *   params: z.object({}).describe('No parameters.'),
+ *   handler(_params, ctx) {
+ *     return '<html>...</html>';
+ *   },
+ * });
+ * ```
+ */
+export function appResource<
+  TParams extends ZodObject<ZodRawShape>,
+  TOutput extends ZodObject<ZodRawShape> | undefined = undefined,
+>(
+  uriTemplate: string,
+  options: AppResourceOptions<TParams, TOutput>,
+): ResourceDefinition<TParams, TOutput> {
+  const { mimeType, annotations, ...rest } = options;
+
+  return resource(uriTemplate, {
+    ...rest,
+    mimeType: mimeType ?? APP_RESOURCE_MIME_TYPE,
+    annotations: {
+      audience: ['user'],
+      ...annotations,
+    },
+  });
+}

--- a/src/mcp-server/apps/appBuilders.ts
+++ b/src/mcp-server/apps/appBuilders.ts
@@ -36,8 +36,9 @@ type AppToolOptions<
   TOutput extends ZodObject<ZodRawShape>,
 > = Omit<ToolDefinition<TInput, TOutput>, '_meta' | 'name'> & {
   /**
-   * Additional `_meta` fields beyond the auto-populated `ui` and compat key.
-   * Merged with the generated `_meta.ui` — do not set `ui` or `ui/resourceUri` here.
+   * Additional `_meta` fields. `ui` sub-fields (e.g. `csp`, `visibility`, `permissions`)
+   * are merged with the auto-populated `resourceUri`. The `resourceUri` value from the
+   * top-level option always wins — it cannot be overridden via `extraMeta.ui.resourceUri`.
    */
   extraMeta?: Record<string, unknown>;
   /** URI of the `ui://` resource that hosts will fetch and render as a sandboxed iframe. */
@@ -67,12 +68,18 @@ export function appTool<
   TOutput extends ZodObject<ZodRawShape>,
 >(name: string, options: AppToolOptions<TInput, TOutput>): ToolDefinition<TInput, TOutput> {
   const { resourceUri, extraMeta, ...rest } = options;
+  const { ui: extraUi, ...extraMetaRest } = extraMeta ?? {};
 
   return tool(name, {
     ...rest,
     _meta: {
-      ...extraMeta,
-      ui: { resourceUri },
+      ...extraMetaRest,
+      ui: {
+        ...(typeof extraUi === 'object' && extraUi !== null
+          ? (extraUi as Record<string, unknown>)
+          : {}),
+        resourceUri,
+      },
       [RESOURCE_URI_META_KEY]: resourceUri,
     },
   });

--- a/src/mcp-server/resources/resource-registration.ts
+++ b/src/mcp-server/resources/resource-registration.ts
@@ -97,6 +97,7 @@ export class ResourceRegistry {
             ...(def.size != null && { size: def.size }),
             ...(def.examples && { examples: def.examples }),
             ...(def.annotations && { annotations: def.annotations }),
+            ...(def._meta && { _meta: def._meta }),
           },
           handler,
         );

--- a/src/mcp-server/resources/utils/resourceDefinition.ts
+++ b/src/mcp-server/resources/utils/resourceDefinition.ts
@@ -42,6 +42,19 @@ export interface ResourceDefinition<
   TParams extends ZodObject<ZodRawShape> = ZodObject<ZodRawShape>,
   TOutput extends ZodObject<ZodRawShape> | undefined = undefined,
 > {
+  /**
+   * Protocol-level metadata for the resource.
+   * For MCP Apps UI resources, use `_meta.ui` to declare CSP and permissions:
+   * ```ts
+   * _meta: {
+   *   ui: {
+   *     csp: { resource_domains: ['https://cdn.example.com'] },
+   *     permissions: ['microphone'],
+   *   },
+   * }
+   * ```
+   */
+  _meta?: Record<string, unknown>;
   /** Display/behavior hints. */
   annotations?: ResourceAnnotations;
   /** Required auth scopes. */

--- a/src/mcp-server/resources/utils/resourceDefinition.ts
+++ b/src/mcp-server/resources/utils/resourceDefinition.ts
@@ -48,7 +48,7 @@ export interface ResourceDefinition<
    * ```ts
    * _meta: {
    *   ui: {
-   *     csp: { resource_domains: ['https://cdn.example.com'] },
+   *     csp: { resourceDomains: ['https://cdn.example.com'] },
    *     permissions: ['microphone'],
    *   },
    * }

--- a/src/mcp-server/tasks/utils/taskToolDefinition.ts
+++ b/src/mcp-server/tasks/utils/taskToolDefinition.ts
@@ -53,6 +53,9 @@ export interface TaskToolDefinition<
   TInputSchema extends ZodObject<ZodRawShape>,
   TOutputSchema extends ZodObject<ZodRawShape>,
 > {
+  /** Protocol-level metadata (e.g., MCP Apps extension `_meta.ui`). */
+  _meta?: Record<string, unknown>;
+
   /**
    * Optional metadata providing hints about the tool's behavior.
    */

--- a/src/mcp-server/tools/tool-registration.ts
+++ b/src/mcp-server/tools/tool-registration.ts
@@ -219,6 +219,7 @@ export class ToolRegistry {
             inputSchema: tool.input,
             outputSchema: tool.output,
             ...(tool.annotations && { annotations: tool.annotations }),
+            ...(tool._meta && { _meta: tool._meta }),
             execution: { taskSupport: 'optional' },
           },
           {
@@ -405,6 +406,7 @@ export class ToolRegistry {
             inputSchema: tool.input,
             ...(tool.output && { outputSchema: tool.output }),
             ...(tool.annotations && { annotations: tool.annotations }),
+            ...(tool._meta && { _meta: tool._meta }),
             execution: tool.execution,
           },
           tool.taskHandlers,

--- a/templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts
+++ b/templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview UI resource for the echo MCP App.
+ * Serves a self-contained HTML application that renders echo results
+ * and lets users send new echo requests from the UI.
+ * @module mcp-server/resources/definitions/echo-app-ui.app-resource
+ */
+
+import { appResource, z } from '@cyanheads/mcp-ts-core';
+
+const ParamsSchema = z.object({}).describe('No parameters. Returns the static HTML app.');
+
+// ─── HTML Application ─────────────────────────────────────────────────────────
+
+const APP_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Echo App</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #0f172a; color: #e2e8f0;
+      padding: 1.5rem; min-height: 100vh;
+      display: flex; flex-direction: column; align-items: center; gap: 1rem;
+    }
+    h1 { font-size: 1.25rem; font-weight: 600; }
+    .card {
+      background: #1e293b; border: 1px solid #334155; border-radius: 0.5rem;
+      padding: 1rem 1.25rem; width: 100%; max-width: 480px;
+    }
+    .label { font-size: 0.75rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; }
+    .value { font-size: 1rem; margin-top: 0.25rem; word-break: break-word; }
+    .controls { display: flex; gap: 0.5rem; width: 100%; max-width: 480px; }
+    input[type="text"] {
+      flex: 1; padding: 0.5rem 0.75rem; background: #1e293b; border: 1px solid #334155;
+      border-radius: 0.375rem; color: #e2e8f0; font-size: 0.875rem; outline: none;
+    }
+    input[type="text"]:focus { border-color: #3b82f6; }
+    button {
+      padding: 0.5rem 1rem; background: #3b82f6; color: #fff; border: none;
+      border-radius: 0.375rem; font-size: 0.875rem; cursor: pointer;
+    }
+    button:hover { background: #2563eb; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+  </style>
+</head>
+<body>
+  <h1>Echo App</h1>
+  <div class="card">
+    <div class="label">Message</div>
+    <div class="value" id="message">Waiting for data…</div>
+  </div>
+  <div class="card">
+    <div class="label">Timestamp</div>
+    <div class="value" id="timestamp">—</div>
+  </div>
+  <div class="controls">
+    <input type="text" id="input" placeholder="Type a message…" />
+    <button id="send">Echo</button>
+  </div>
+
+  <script type="module">
+    import { App } from "https://unpkg.com/@modelcontextprotocol/ext-apps@1/app-with-deps";
+
+    const app = new App({ name: "Echo App", version: "1.0.0" });
+    const messageEl = document.getElementById("message");
+    const timestampEl = document.getElementById("timestamp");
+    const inputEl = document.getElementById("input");
+    const sendBtn = document.getElementById("send");
+
+    function render(content) {
+      const text = content?.find(c => c.type === "text")?.text;
+      if (!text) return;
+      try {
+        const data = JSON.parse(text);
+        messageEl.textContent = data.message ?? "—";
+        timestampEl.textContent = data.timestamp ?? "—";
+      } catch { /* ignore malformed */ }
+    }
+
+    // Receive initial tool result pushed by the host
+    app.ontoolresult = (result) => render(result.content);
+
+    // Send new echo from the UI
+    sendBtn.addEventListener("click", async () => {
+      const msg = inputEl.value.trim();
+      if (!msg) return;
+      sendBtn.disabled = true;
+      try {
+        const result = await app.callServerTool({
+          name: "template_echo_app",
+          arguments: { message: msg },
+        });
+        render(result.content);
+        inputEl.value = "";
+      } catch (err) {
+        console.error("Echo failed:", err);
+      } finally {
+        sendBtn.disabled = false;
+      }
+    });
+
+    inputEl.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") sendBtn.click();
+    });
+
+    await app.connect();
+  </script>
+</body>
+</html>`;
+
+// ─── Definition ───────────────────────────────────────────────────────────────
+
+export const echoAppUiResource = appResource('ui://template-echo-app/app.html', {
+  name: 'echo-app-ui',
+  title: 'Echo App UI',
+  description:
+    'Interactive HTML app for the echo app tool. Displayed as a sandboxed iframe ' +
+    'by MCP Apps-capable hosts.',
+  params: ParamsSchema,
+  auth: ['resource:echo-app-ui:read'],
+
+  handler(_params, ctx) {
+    ctx.log.debug('Serving echo app UI.', { resourceUri: ctx.uri?.href });
+    return APP_HTML;
+  },
+
+  list: () => ({
+    resources: [
+      {
+        uri: 'ui://template-echo-app/app.html',
+        name: 'Echo App',
+        description: 'Interactive echo UI for the template_echo_app tool.',
+      },
+    ],
+  }),
+});

--- a/templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts
+++ b/templates/src/mcp-server/resources/definitions/echo-app-ui.app-resource.ts
@@ -119,6 +119,11 @@ export const echoAppUiResource = appResource('ui://template-echo-app/app.html', 
   description:
     'Interactive HTML app for the echo app tool. Displayed as a sandboxed iframe ' +
     'by MCP Apps-capable hosts.',
+  _meta: {
+    ui: {
+      csp: { resourceDomains: ['https://unpkg.com'] },
+    },
+  },
   params: ParamsSchema,
   auth: ['resource:echo-app-ui:read'],
 

--- a/templates/src/mcp-server/tools/definitions/echo-app.app-tool.ts
+++ b/templates/src/mcp-server/tools/definitions/echo-app.app-tool.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview MCP App tool — interactive echo with a UI component.
+ * Demonstrates the MCP Apps extension: the tool returns structured data,
+ * and the linked UI resource renders it as an interactive HTML interface.
+ * Hosts without MCP Apps support receive the plain text fallback from format().
+ * @module mcp-server/tools/definitions/echo-app.app-tool
+ */
+
+import { appTool, z } from '@cyanheads/mcp-ts-core';
+
+/** The UI resource URI that hosts fetch and render as a sandboxed iframe. */
+const UI_RESOURCE_URI = 'ui://template-echo-app/app.html';
+
+export const echoAppTool = appTool('template_echo_app', {
+  resourceUri: UI_RESOURCE_URI,
+  title: 'Echo App',
+  description:
+    'Echoes a message with an interactive UI. Demonstrates MCP Apps — hosts that support ' +
+    'the extension render an HTML interface; others receive a text fallback.',
+  annotations: { readOnlyHint: true },
+  input: z.object({
+    message: z.string().describe('The message to echo.'),
+  }),
+  output: z.object({
+    message: z.string().describe('The echoed message.'),
+    timestamp: z.string().describe('ISO 8601 timestamp of the echo.'),
+  }),
+
+  handler(input, ctx) {
+    ctx.log.debug('Echo app called.', { message: input.message });
+    return {
+      message: input.message,
+      timestamp: new Date().toISOString(),
+    };
+  },
+
+  format(result) {
+    // First block: JSON for the MCP App UI (ontoolresult parses first text block)
+    const jsonBlock = JSON.stringify(result);
+
+    // Second block: human-readable fallback for non-app hosts / LLM context
+    const textBlock = `**Echo:** ${result.message}\n**Time:** ${result.timestamp}`;
+
+    return [
+      { type: 'text', text: jsonBlock },
+      { type: 'text', text: textBlock },
+    ];
+  },
+});

--- a/tests/integration/mcp-apps.int.test.ts
+++ b/tests/integration/mcp-apps.int.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @fileoverview Integration tests for MCP Apps end-to-end pipeline.
+ * Validates the full flow: appTool()/appResource() builders → linter validation →
+ * registration passthrough → handler execution → format output.
+ * @module tests/integration/mcp-apps.int.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { validateDefinitions } from '@/linter/validate.js';
+import { APP_RESOURCE_MIME_TYPE, appResource, appTool } from '@/mcp-server/apps/appBuilders.js';
+import { createMockContext } from '@/testing/index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures: a paired app tool + resource
+// ---------------------------------------------------------------------------
+
+const UI_URI = 'ui://test-app/app.html';
+
+function createAppToolDef() {
+  return appTool('test_app_tool', {
+    resourceUri: UI_URI,
+    title: 'Test App',
+    description: 'Integration test app tool.',
+    annotations: { readOnlyHint: true },
+    input: z.object({
+      query: z.string().describe('Search query'),
+      limit: z.number().default(10).describe('Max results'),
+    }),
+    output: z.object({
+      items: z.array(z.string()).describe('Result items'),
+      total: z.number().describe('Total count'),
+    }),
+    auth: ['tool:test_app:read'],
+
+    async handler(input, ctx) {
+      ctx.log.info('App tool called', { query: input.query });
+      const items = Array.from({ length: input.limit }, (_, i) => `${input.query}-${i}`);
+      return { items, total: items.length };
+    },
+
+    format(result) {
+      return [
+        { type: 'text', text: JSON.stringify(result) },
+        { type: 'text', text: `Found ${result.total} items` },
+      ];
+    },
+  });
+}
+
+function createAppResourceDef() {
+  return appResource(UI_URI, {
+    name: 'test-app-ui',
+    title: 'Test App UI',
+    description: 'UI resource for test_app_tool.',
+    params: z.object({}).describe('No parameters.'),
+    auth: ['resource:test-app-ui:read'],
+    _meta: {
+      ui: {
+        csp: { resource_domains: ['https://cdn.example.com'] },
+      },
+    },
+
+    handler(_params, ctx) {
+      ctx.log.debug('Serving test app UI.');
+      return '<html><body>Test App</body></html>';
+    },
+
+    list: () => ({
+      resources: [{ uri: UI_URI, name: 'Test App', description: 'Test app UI.' }],
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MCP Apps — end-to-end integration', () => {
+  describe('builder output structure', () => {
+    it('appTool produces correct _meta with ui and compat key', () => {
+      const tool = createAppToolDef();
+      expect(tool._meta).toMatchObject({
+        ui: { resourceUri: UI_URI },
+        'ui/resourceUri': UI_URI,
+      });
+    });
+
+    it('appResource produces correct mimeType and audience', () => {
+      const resource = createAppResourceDef();
+      expect(resource.mimeType).toBe(APP_RESOURCE_MIME_TYPE);
+      expect(resource.annotations?.audience).toEqual(['user']);
+    });
+
+    it('tool and resource URIs match', () => {
+      const tool = createAppToolDef();
+      const resource = createAppResourceDef();
+      const toolUri = (tool._meta?.ui as { resourceUri: string }).resourceUri;
+      expect(toolUri).toBe(resource.uriTemplate);
+    });
+  });
+
+  describe('linter validation', () => {
+    it('paired app tool + resource passes validation', () => {
+      const report = validateDefinitions({
+        tools: [createAppToolDef()],
+        resources: [createAppResourceDef()],
+      });
+
+      expect(report.passed).toBe(true);
+      expect(report.errors).toHaveLength(0);
+
+      // No pairing warnings since tool and resource URI match
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(0);
+
+      // No _meta.ui warnings since URI uses ui:// scheme
+      const schemeWarnings = report.warnings.filter(
+        (w) => w.rule === 'meta-ui-resource-uri-scheme',
+      );
+      expect(schemeWarnings).toHaveLength(0);
+    });
+
+    it('app tool without matching resource triggers pairing warning', () => {
+      const report = validateDefinitions({
+        tools: [createAppToolDef()],
+        resources: [], // no matching resource
+      });
+
+      expect(report.passed).toBe(true); // warnings don't fail
+      expect(report.warnings).toContainEqual(
+        expect.objectContaining({
+          rule: 'app-tool-resource-pairing',
+          definitionName: 'test_app_tool',
+        }),
+      );
+    });
+
+    it('validates alongside standard tools and resources', () => {
+      const standardTool = {
+        name: 'plain_tool',
+        description: 'A regular tool',
+        input: z.object({ x: z.string().describe('X') }),
+        output: z.object({ ok: z.boolean().describe('OK') }),
+        handler: () => ({ ok: true }),
+      };
+      const standardResource = {
+        uriTemplate: 'data://{id}',
+        name: 'data-resource',
+        description: 'A regular resource',
+        handler: () => ({}),
+      };
+
+      const report = validateDefinitions({
+        tools: [createAppToolDef(), standardTool],
+        resources: [createAppResourceDef(), standardResource],
+      });
+
+      expect(report.passed).toBe(true);
+      expect(report.errors).toHaveLength(0);
+    });
+  });
+
+  describe('handler execution', () => {
+    it('app tool handler processes input and returns typed output', async () => {
+      const tool = createAppToolDef();
+      const ctx = createMockContext();
+      const input = tool.input.parse({ query: 'test', limit: 3 });
+      const result = await tool.handler(input, ctx);
+
+      expect(result.items).toEqual(['test-0', 'test-1', 'test-2']);
+      expect(result.total).toBe(3);
+
+      // Output validates against schema
+      const parsed = tool.output.parse(result);
+      expect(parsed).toEqual(result);
+    });
+
+    it('app tool format produces dual blocks (JSON + text)', async () => {
+      const tool = createAppToolDef();
+      const ctx = createMockContext();
+      const input = tool.input.parse({ query: 'search' });
+      const result = await tool.handler(input, ctx);
+      const blocks = tool.format!(result);
+
+      expect(blocks).toHaveLength(2);
+
+      // First block: JSON for UI consumption
+      const json = JSON.parse((blocks[0] as { text: string }).text);
+      expect(json.items).toEqual(result.items);
+      expect(json.total).toBe(result.total);
+
+      // Second block: human-readable fallback
+      expect((blocks[1] as { text: string }).text).toContain('10 items');
+    });
+
+    it('app resource handler returns HTML', () => {
+      const resource = createAppResourceDef();
+      const ctx = createMockContext({
+        uri: new URL('ui://test-app/app.html'),
+      });
+      const params = resource.params!.parse({});
+      const result = resource.handler(params, ctx);
+
+      expect(typeof result).toBe('string');
+      expect(result).toContain('<html>');
+    });
+
+    it('app resource list returns discoverable entry', async () => {
+      const resource = createAppResourceDef();
+      const extra = {
+        signal: new AbortController().signal,
+        requestId: 'test',
+        sendNotification: () => Promise.resolve(),
+        sendRequest: () => Promise.resolve({} as never),
+      };
+      const listing = await resource.list!(extra);
+
+      expect(listing.resources).toHaveLength(1);
+      expect(listing.resources[0]!.uri).toBe(UI_URI);
+    });
+  });
+
+  describe('cross-definition consistency', () => {
+    it('tool resourceUri matches resource uriTemplate', () => {
+      const tool = createAppToolDef();
+      const resource = createAppResourceDef();
+
+      const toolResourceUri = (tool._meta?.ui as Record<string, unknown>).resourceUri as string;
+      const compatUri = tool._meta?.['ui/resourceUri'] as string;
+
+      expect(toolResourceUri).toBe(resource.uriTemplate);
+      expect(compatUri).toBe(resource.uriTemplate);
+    });
+
+    it('resource list URI matches its own uriTemplate', async () => {
+      const resource = createAppResourceDef();
+      const listing = await resource.list!({
+        signal: new AbortController().signal,
+        requestId: 'test',
+        sendNotification: () => Promise.resolve(),
+        sendRequest: () => Promise.resolve({} as never),
+      });
+
+      expect(listing.resources[0]!.uri).toBe(resource.uriTemplate);
+    });
+  });
+});

--- a/tests/smoke/resources/echo-app-ui.app-resource.test.ts
+++ b/tests/smoke/resources/echo-app-ui.app-resource.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Smoke tests for the MCP Apps echo app UI resource pattern.
+ * Uses appResource() builder directly to validate the same pattern as the
+ * template (templates/ has its own package.json that prevents direct import).
+ * @module tests/smoke/resources/echo-app-ui.app-resource.test
+ */
+
+import { APP_RESOURCE_MIME_TYPE } from '@cyanheads/mcp-ts-core';
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { appResource } from '@/mcp-server/apps/appBuilders.js';
+
+/** Mirrors the template echo app UI resource. */
+const echoAppUiResource = appResource('ui://template-echo-app/app.html', {
+  name: 'echo-app-ui',
+  title: 'Echo App UI',
+  description: 'Interactive HTML app for the echo app tool.',
+  params: z.object({}).describe('No parameters. Returns the static HTML app.'),
+  auth: ['resource:echo-app-ui:read'],
+
+  handler(_params, ctx) {
+    ctx.log.debug('Serving echo app UI.', { resourceUri: ctx.uri?.href });
+    return '<!DOCTYPE html><html lang="en"><head><title>Echo App</title></head><body><h1>Echo App</h1><script type="module">import{App}from"https://unpkg.com/@modelcontextprotocol/ext-apps@1/app-with-deps";const app=new App({name:"Echo App",version:"1.0.0"});app.ontoolresult=(r)=>{};await app.connect();</script></body></html>';
+  },
+
+  list: () => ({
+    resources: [
+      {
+        uri: 'ui://template-echo-app/app.html',
+        name: 'Echo App',
+        description: 'Interactive echo UI for the template_echo_app tool.',
+      },
+    ],
+  }),
+});
+
+describe('echoAppUiResource (MCP Apps pattern)', () => {
+  it('has the correct URI template', () => {
+    expect(echoAppUiResource.uriTemplate).toBe('ui://template-echo-app/app.html');
+  });
+
+  it('has the MCP Apps MIME type', () => {
+    expect(echoAppUiResource.mimeType).toBe(APP_RESOURCE_MIME_TYPE);
+    expect(echoAppUiResource.mimeType).toBe('text/html;profile=mcp-app');
+  });
+
+  it('has audience: ["user"] annotation', () => {
+    expect(echoAppUiResource.annotations?.audience).toEqual(['user']);
+  });
+
+  it('has a name', () => {
+    expect(echoAppUiResource.name).toBe('echo-app-ui');
+  });
+
+  it('has a title', () => {
+    expect(echoAppUiResource.title).toBe('Echo App UI');
+  });
+
+  it('has auth scopes', () => {
+    expect(echoAppUiResource.auth).toEqual(['resource:echo-app-ui:read']);
+  });
+
+  it('handler returns HTML content', async () => {
+    const ctx = createMockContext({ uri: new URL('ui://template-echo-app/app.html') });
+    const params = echoAppUiResource.params!.parse({});
+    const result = await echoAppUiResource.handler(params, ctx);
+    expect(typeof result).toBe('string');
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('Echo App');
+  });
+
+  it('HTML includes the MCP Apps client SDK import', async () => {
+    const ctx = createMockContext({ uri: new URL('ui://template-echo-app/app.html') });
+    const result = await echoAppUiResource.handler(echoAppUiResource.params!.parse({}), ctx);
+    expect(result).toContain('@modelcontextprotocol/ext-apps');
+    expect(result).toContain('app.connect()');
+  });
+
+  it('list returns the resource entry', async () => {
+    const extra = {
+      signal: new AbortController().signal,
+      requestId: 'test',
+      sendNotification: () => Promise.resolve(),
+      sendRequest: () => Promise.resolve({} as never),
+    };
+    const listing = await echoAppUiResource.list!(extra);
+    expect(listing.resources).toHaveLength(1);
+    expect(listing.resources[0]).toMatchObject({
+      uri: 'ui://template-echo-app/app.html',
+      name: 'Echo App',
+    });
+  });
+});

--- a/tests/smoke/tools/template-echo-app.app-tool.test.ts
+++ b/tests/smoke/tools/template-echo-app.app-tool.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @fileoverview Smoke tests for the MCP Apps echo app tool pattern.
+ * Uses appTool() builder directly to validate the same pattern as the
+ * template (templates/ has its own package.json that prevents direct import).
+ * @module tests/smoke/tools/template-echo-app.app-tool.test
+ */
+
+import { createMockContext } from '@cyanheads/mcp-ts-core/testing';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { appTool } from '@/mcp-server/apps/appBuilders.js';
+
+/** Mirrors the template echo app tool definition. */
+const UI_RESOURCE_URI = 'ui://template-echo-app/app.html';
+
+const echoAppTool = appTool('template_echo_app', {
+  resourceUri: UI_RESOURCE_URI,
+  title: 'Echo App',
+  description: 'Echoes a message with an interactive UI.',
+  annotations: { readOnlyHint: true },
+  input: z.object({
+    message: z.string().describe('The message to echo.'),
+  }),
+  output: z.object({
+    message: z.string().describe('The echoed message.'),
+    timestamp: z.string().describe('ISO 8601 timestamp of the echo.'),
+  }),
+
+  handler(input, ctx) {
+    ctx.log.debug('Echo app called.', { message: input.message });
+    return {
+      message: input.message,
+      timestamp: new Date().toISOString(),
+    };
+  },
+
+  format(result) {
+    const jsonBlock = JSON.stringify(result);
+    const textBlock = `**Echo:** ${result.message}\n**Time:** ${result.timestamp}`;
+    return [
+      { type: 'text', text: jsonBlock },
+      { type: 'text', text: textBlock },
+    ];
+  },
+});
+
+describe('echoAppTool (MCP Apps pattern)', () => {
+  it('echoes the input message', async () => {
+    const ctx = createMockContext();
+    const input = echoAppTool.input.parse({ message: 'hello world' });
+    const result = await echoAppTool.handler(input, ctx);
+    expect(result.message).toBe('hello world');
+  });
+
+  it('includes an ISO 8601 timestamp', async () => {
+    const ctx = createMockContext();
+    const input = echoAppTool.input.parse({ message: 'test' });
+    const result = await echoAppTool.handler(input, ctx);
+    expect(() => new Date(result.timestamp).toISOString()).not.toThrow();
+  });
+
+  it('output validates against the output schema', async () => {
+    const ctx = createMockContext();
+    const input = echoAppTool.input.parse({ message: 'test' });
+    const result = await echoAppTool.handler(input, ctx);
+    const parsed = echoAppTool.output.parse(result);
+    expect(parsed.message).toBe('test');
+    expect(parsed.timestamp).toBe(result.timestamp);
+  });
+
+  it('format returns JSON block + text block', () => {
+    const result = {
+      message: 'hello',
+      timestamp: '2026-04-06T12:00:00.000Z',
+    };
+    const blocks = echoAppTool.format!(result);
+
+    expect(blocks).toHaveLength(2);
+
+    // First block: parseable JSON for the MCP App UI
+    const jsonBlock = (blocks[0] as { text: string }).text;
+    const parsed = JSON.parse(jsonBlock);
+    expect(parsed.message).toBe('hello');
+    expect(parsed.timestamp).toBe('2026-04-06T12:00:00.000Z');
+
+    // Second block: human-readable fallback
+    const textBlock = (blocks[1] as { text: string }).text;
+    expect(textBlock).toContain('hello');
+    expect(textBlock).toContain('2026-04-06T12:00:00.000Z');
+  });
+
+  it('has _meta.ui.resourceUri pointing to the echo app UI', () => {
+    expect(echoAppTool._meta?.ui).toEqual({
+      resourceUri: UI_RESOURCE_URI,
+    });
+  });
+
+  it('has _meta["ui/resourceUri"] compat key', () => {
+    expect(echoAppTool._meta?.['ui/resourceUri']).toBe(UI_RESOURCE_URI);
+  });
+
+  it('has readOnlyHint annotation', () => {
+    expect(echoAppTool.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('has a title', () => {
+    expect(echoAppTool.title).toBe('Echo App');
+  });
+
+  it('rejects missing message via input schema', () => {
+    const result = echoAppTool.input.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/unit/linter/tool-rules.test.ts
+++ b/tests/unit/linter/tool-rules.test.ts
@@ -1,0 +1,285 @@
+/**
+ * @fileoverview Tests for tool-specific lint rules, focused on _meta.ui
+ * validation and the app tool ↔ resource pairing cross-check.
+ * @module tests/unit/linter/tool-rules.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import {
+  lintAppToolResourcePairing,
+  lintAuthScopes,
+  lintToolDefinition,
+} from '@/linter/rules/tool-rules.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validTool(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'test_tool',
+    description: 'A test tool',
+    input: z.object({ query: z.string().describe('Search query') }),
+    output: z.object({ result: z.string().describe('Result') }),
+    handler: async () => ({ result: 'ok' }),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// lintToolDefinition — _meta.ui validation
+// ---------------------------------------------------------------------------
+
+describe('lintToolDefinition — _meta.ui', () => {
+  it('produces no diagnostics when _meta is absent', () => {
+    const diagnostics = lintToolDefinition(validTool());
+    const metaDiags = diagnostics.filter((d) => d.rule.startsWith('meta-ui'));
+    expect(metaDiags).toHaveLength(0);
+  });
+
+  it('produces no diagnostics when _meta has no ui key', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { custom: true } }));
+    const metaDiags = diagnostics.filter((d) => d.rule.startsWith('meta-ui'));
+    expect(metaDiags).toHaveLength(0);
+  });
+
+  it('errors when _meta.ui is a string', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: 'string-value' } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        rule: 'meta-ui-type',
+        severity: 'error',
+      }),
+    );
+  });
+
+  it('errors when _meta.ui is a number', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: 42 } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-type', severity: 'error' }),
+    );
+  });
+
+  it('errors when _meta.ui is null', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: null } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-type', severity: 'error' }),
+    );
+  });
+
+  it('errors when _meta.ui is an array', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: ['bad'] } }));
+    // Arrays are objects, so this should hit resourceUri-required instead
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-resource-uri-required', severity: 'error' }),
+    );
+  });
+
+  it('errors when _meta.ui is present but resourceUri is missing', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: { other: true } } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        rule: 'meta-ui-resource-uri-required',
+        severity: 'error',
+        message: expect.stringContaining('missing a valid resourceUri'),
+      }),
+    );
+  });
+
+  it('errors when _meta.ui.resourceUri is empty string', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: { resourceUri: '' } } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-resource-uri-required' }),
+    );
+  });
+
+  it('errors when _meta.ui.resourceUri is not a string', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: { resourceUri: 123 } } }));
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-resource-uri-required' }),
+    );
+  });
+
+  it('warns when resourceUri does not use ui:// scheme', () => {
+    const diagnostics = lintToolDefinition(
+      validTool({ _meta: { ui: { resourceUri: 'https://example.com/ui.html' } } }),
+    );
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({
+        rule: 'meta-ui-resource-uri-scheme',
+        severity: 'warning',
+        message: expect.stringContaining('does not use the ui:// scheme'),
+      }),
+    );
+  });
+
+  it('warns when resourceUri uses http:// scheme', () => {
+    const diagnostics = lintToolDefinition(
+      validTool({ _meta: { ui: { resourceUri: 'http://localhost:3000/app.html' } } }),
+    );
+    expect(diagnostics).toContainEqual(
+      expect.objectContaining({ rule: 'meta-ui-resource-uri-scheme', severity: 'warning' }),
+    );
+  });
+
+  it('passes with valid ui:// resourceUri', () => {
+    const diagnostics = lintToolDefinition(
+      validTool({ _meta: { ui: { resourceUri: 'ui://my-app/app.html' } } }),
+    );
+    const metaDiags = diagnostics.filter((d) => d.rule.startsWith('meta-ui'));
+    expect(metaDiags).toHaveLength(0);
+  });
+
+  it('includes tool name in diagnostic messages', () => {
+    const diagnostics = lintToolDefinition(validTool({ name: 'my_app_tool', _meta: { ui: {} } }));
+    const metaDiag = diagnostics.find((d) => d.rule === 'meta-ui-resource-uri-required');
+    expect(metaDiag?.message).toContain('my_app_tool');
+    expect(metaDiag?.definitionName).toBe('my_app_tool');
+  });
+
+  it('uses <unnamed> for tools without a name', () => {
+    const toolDef = validTool({ _meta: { ui: {} } });
+    delete (toolDef as Record<string, unknown>).name;
+    const diagnostics = lintToolDefinition(toolDef);
+    const metaDiag = diagnostics.find((d) => d.rule === 'meta-ui-resource-uri-required');
+    expect(metaDiag?.message).toContain('<unnamed>');
+  });
+
+  it('does not produce scheme warning when resourceUri is invalid type (error takes precedence)', () => {
+    const diagnostics = lintToolDefinition(validTool({ _meta: { ui: { resourceUri: 42 } } }));
+    // Should only get the required error, not the scheme warning
+    const schemeWarnings = diagnostics.filter((d) => d.rule === 'meta-ui-resource-uri-scheme');
+    expect(schemeWarnings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintAppToolResourcePairing
+// ---------------------------------------------------------------------------
+
+describe('lintAppToolResourcePairing', () => {
+  it('returns no diagnostics for empty arrays', () => {
+    expect(lintAppToolResourcePairing([], [])).toHaveLength(0);
+  });
+
+  it('returns no diagnostics for tools without _meta.ui', () => {
+    const diagnostics = lintAppToolResourcePairing(
+      [validTool(), validTool({ name: 'another_tool' })],
+      [],
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('returns no diagnostics when all resourceUris match', () => {
+    const tools = [
+      validTool({
+        name: 'app_a',
+        _meta: { ui: { resourceUri: 'ui://app-a/app.html' } },
+      }),
+      validTool({
+        name: 'app_b',
+        _meta: { ui: { resourceUri: 'ui://app-b/app.html' } },
+      }),
+    ];
+    const resources = [
+      { uriTemplate: 'ui://app-a/app.html', name: 'app-a-ui' },
+      { uriTemplate: 'ui://app-b/app.html', name: 'app-b-ui' },
+    ];
+
+    expect(lintAppToolResourcePairing(tools, resources)).toHaveLength(0);
+  });
+
+  it('warns for each unmatched resourceUri', () => {
+    const tools = [
+      validTool({
+        name: 'app_a',
+        _meta: { ui: { resourceUri: 'ui://app-a/app.html' } },
+      }),
+      validTool({
+        name: 'app_b',
+        _meta: { ui: { resourceUri: 'ui://app-b/app.html' } },
+      }),
+    ];
+    const resources = [{ uriTemplate: 'ui://app-a/app.html', name: 'app-a-ui' }];
+
+    const diagnostics = lintAppToolResourcePairing(tools, resources);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'app-tool-resource-pairing',
+      severity: 'warning',
+      definitionName: 'app_b',
+    });
+  });
+
+  it('warning message includes the resourceUri', () => {
+    const diagnostics = lintAppToolResourcePairing(
+      [validTool({ name: 'app_x', _meta: { ui: { resourceUri: 'ui://app-x/ui.html' } } })],
+      [],
+    );
+    expect(diagnostics[0]!.message).toContain('ui://app-x/ui.html');
+  });
+
+  it('ignores tools with _meta but no ui', () => {
+    const diagnostics = lintAppToolResourcePairing([validTool({ _meta: { custom: true } })], []);
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('ignores tools with _meta.ui but non-string resourceUri', () => {
+    const diagnostics = lintAppToolResourcePairing(
+      [validTool({ _meta: { ui: { resourceUri: 42 } } })],
+      [],
+    );
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('ignores resources without uriTemplate', () => {
+    const diagnostics = lintAppToolResourcePairing(
+      [validTool({ name: 'app', _meta: { ui: { resourceUri: 'ui://app/app.html' } } })],
+      [{ name: 'no-uri' }],
+    );
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it('falls back to <unnamed> for tools without a name', () => {
+    const t = validTool({ _meta: { ui: { resourceUri: 'ui://x/app.html' } } });
+    delete (t as Record<string, unknown>).name;
+
+    const diagnostics = lintAppToolResourcePairing([t], []);
+    expect(diagnostics[0]!.definitionName).toBe('<unnamed>');
+  });
+
+  it('handles mixed app and non-app tools', () => {
+    const tools = [
+      validTool({ name: 'regular_tool' }),
+      validTool({
+        name: 'app_tool',
+        _meta: { ui: { resourceUri: 'ui://app/app.html' } },
+      }),
+    ];
+    const resources = [{ uriTemplate: 'ui://app/app.html', name: 'app-ui' }];
+
+    expect(lintAppToolResourcePairing(tools, resources)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lintAuthScopes (verify existing export still works)
+// ---------------------------------------------------------------------------
+
+describe('lintAuthScopes', () => {
+  it('passes with valid string array', () => {
+    expect(lintAuthScopes(['scope:read', 'scope:write'], 'tool', 'test')).toHaveLength(0);
+  });
+
+  it('errors on non-array', () => {
+    const diagnostics = lintAuthScopes('scope:read', 'tool', 'test');
+    expect(diagnostics).toContainEqual(expect.objectContaining({ rule: 'auth-type' }));
+  });
+
+  it('errors on empty string in array', () => {
+    const diagnostics = lintAuthScopes(['scope:read', ''], 'tool', 'test');
+    expect(diagnostics).toContainEqual(expect.objectContaining({ rule: 'auth-scope-format' }));
+  });
+});

--- a/tests/unit/linter/tool-rules.test.ts
+++ b/tests/unit/linter/tool-rules.test.ts
@@ -250,6 +250,43 @@ describe('lintAppToolResourcePairing', () => {
     expect(diagnostics[0]!.definitionName).toBe('<unnamed>');
   });
 
+  it('matches {+path} operator (reserved expansion with slashes)', () => {
+    const tools = [
+      validTool({
+        name: 'app_dynamic',
+        _meta: { ui: { resourceUri: 'ui://app/a/b/c' } },
+      }),
+    ];
+    const resources = [{ uriTemplate: 'ui://app/{+path}', name: 'app-ui' }];
+
+    expect(lintAppToolResourcePairing(tools, resources)).toHaveLength(0);
+  });
+
+  it('matches {/segments} operator (path segments with slashes)', () => {
+    const tools = [
+      validTool({
+        name: 'app_segments',
+        _meta: { ui: { resourceUri: 'ui://app/x/y' } },
+      }),
+    ];
+    const resources = [{ uriTemplate: 'ui://app{/segments}', name: 'app-ui' }];
+
+    expect(lintAppToolResourcePairing(tools, resources)).toHaveLength(0);
+  });
+
+  it('simple {var} does not match values with slashes', () => {
+    const tools = [
+      validTool({
+        name: 'app_simple',
+        _meta: { ui: { resourceUri: 'ui://app/a/b' } },
+      }),
+    ];
+    const resources = [{ uriTemplate: 'ui://app/{page}', name: 'app-ui' }];
+
+    // {page} only matches single segments — a/b should not match
+    expect(lintAppToolResourcePairing(tools, resources)).toHaveLength(1);
+  });
+
   it('handles mixed app and non-app tools', () => {
     const tools = [
       validTool({ name: 'regular_tool' }),

--- a/tests/unit/linter/validate.test.ts
+++ b/tests/unit/linter/validate.test.ts
@@ -322,6 +322,201 @@ describe('validateDefinitions', () => {
   });
 
   // -------------------------------------------------------------------------
+  // _meta.ui rules (MCP Apps)
+  // -------------------------------------------------------------------------
+
+  describe('_meta.ui rules', () => {
+    it('passes when _meta is absent', () => {
+      const report = validateDefinitions({ tools: [validTool()] });
+      const metaErrors = report.errors.filter((e) => e.rule.startsWith('meta-ui'));
+      expect(metaErrors).toHaveLength(0);
+    });
+
+    it('passes when _meta exists but has no ui key', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { version: '1.0' } })],
+      });
+      const metaErrors = report.errors.filter((e) => e.rule.startsWith('meta-ui'));
+      expect(metaErrors).toHaveLength(0);
+    });
+
+    it('errors when _meta.ui is not an object', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: 'bad' } })],
+      });
+      expect(report.errors).toContainEqual(expect.objectContaining({ rule: 'meta-ui-type' }));
+    });
+
+    it('errors when _meta.ui is null', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: null } })],
+      });
+      expect(report.errors).toContainEqual(expect.objectContaining({ rule: 'meta-ui-type' }));
+    });
+
+    it('errors when _meta.ui.resourceUri is missing', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: {} } })],
+      });
+      expect(report.errors).toContainEqual(
+        expect.objectContaining({ rule: 'meta-ui-resource-uri-required' }),
+      );
+    });
+
+    it('errors when _meta.ui.resourceUri is empty string', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: { resourceUri: '' } } })],
+      });
+      expect(report.errors).toContainEqual(
+        expect.objectContaining({ rule: 'meta-ui-resource-uri-required' }),
+      );
+    });
+
+    it('errors when _meta.ui.resourceUri is not a string', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: { resourceUri: 42 } } })],
+      });
+      expect(report.errors).toContainEqual(
+        expect.objectContaining({ rule: 'meta-ui-resource-uri-required' }),
+      );
+    });
+
+    it('warns when resourceUri does not use ui:// scheme', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: { resourceUri: 'https://example.com/app.html' } } })],
+      });
+      expect(report.warnings).toContainEqual(
+        expect.objectContaining({ rule: 'meta-ui-resource-uri-scheme' }),
+      );
+    });
+
+    it('passes with valid ui:// resourceUri', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: { resourceUri: 'ui://my-app/app.html' } } })],
+        resources: [validResource({ uriTemplate: 'ui://my-app/app.html' })],
+      });
+      const metaErrors = report.errors.filter((e) => e.rule.startsWith('meta-ui'));
+      expect(metaErrors).toHaveLength(0);
+      const metaWarnings = report.warnings.filter((e) => e.rule.startsWith('meta-ui'));
+      expect(metaWarnings).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // App tool ↔ resource pairing
+  // -------------------------------------------------------------------------
+
+  describe('app tool ↔ resource pairing', () => {
+    it('passes when tool resourceUri matches a registered resource', () => {
+      const report = validateDefinitions({
+        tools: [
+          validTool({
+            _meta: { ui: { resourceUri: 'ui://my-app/app.html' } },
+          }),
+        ],
+        resources: [validResource({ uriTemplate: 'ui://my-app/app.html', name: 'my-app-ui' })],
+      });
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(0);
+    });
+
+    it('warns when tool resourceUri has no matching resource', () => {
+      const report = validateDefinitions({
+        tools: [
+          validTool({
+            _meta: { ui: { resourceUri: 'ui://my-app/app.html' } },
+          }),
+        ],
+        resources: [validResource({ uriTemplate: 'other://resource', name: 'other' })],
+      });
+      expect(report.warnings).toContainEqual(
+        expect.objectContaining({
+          rule: 'app-tool-resource-pairing',
+          message: expect.stringContaining('ui://my-app/app.html'),
+        }),
+      );
+    });
+
+    it('warns when tool resourceUri has no resources at all', () => {
+      const report = validateDefinitions({
+        tools: [
+          validTool({
+            _meta: { ui: { resourceUri: 'ui://my-app/app.html' } },
+          }),
+        ],
+        resources: [],
+      });
+      expect(report.warnings).toContainEqual(
+        expect.objectContaining({ rule: 'app-tool-resource-pairing' }),
+      );
+    });
+
+    it('skips tools without _meta.ui', () => {
+      const report = validateDefinitions({
+        tools: [validTool()],
+        resources: [],
+      });
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(0);
+    });
+
+    it('skips tools with _meta but no ui key', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { version: '1.0' } })],
+        resources: [],
+      });
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(0);
+    });
+
+    it('skips tools with non-string resourceUri', () => {
+      const report = validateDefinitions({
+        tools: [validTool({ _meta: { ui: { resourceUri: 42 } } })],
+        resources: [],
+      });
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(0);
+    });
+
+    it('handles multiple app tools with mixed match results', () => {
+      const report = validateDefinitions({
+        tools: [
+          validTool({
+            name: 'matched_tool',
+            _meta: { ui: { resourceUri: 'ui://app-a/app.html' } },
+          }),
+          validTool({
+            name: 'unmatched_tool',
+            _meta: { ui: { resourceUri: 'ui://app-b/app.html' } },
+          }),
+        ],
+        resources: [validResource({ uriTemplate: 'ui://app-a/app.html', name: 'app-a-ui' })],
+      });
+
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(1);
+      expect(pairingWarnings[0]!.definitionName).toBe('unmatched_tool');
+    });
+
+    it('uses <unnamed> for tools without a name', () => {
+      const toolNoName = validTool({
+        _meta: { ui: { resourceUri: 'ui://app/app.html' } },
+      });
+      // Remove name to test fallback
+      delete (toolNoName as Record<string, unknown>).name;
+
+      const report = validateDefinitions({
+        tools: [toolNoName],
+        resources: [],
+      });
+
+      const pairingWarnings = report.warnings.filter((w) => w.rule === 'app-tool-resource-pairing');
+      expect(pairingWarnings).toHaveLength(1);
+      expect(pairingWarnings[0]!.definitionName).toBe('<unnamed>');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Resource rules
   // -------------------------------------------------------------------------
 

--- a/tests/unit/mcp-server/apps/appBuilders.test.ts
+++ b/tests/unit/mcp-server/apps/appBuilders.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @fileoverview Tests for MCP Apps builders — `appTool()` and `appResource()`.
+ * Verifies auto-populated `_meta.ui`, compat keys, MIME type defaults,
+ * annotation defaults, and passthrough of all standard fields.
+ * @module tests/unit/mcp-server/apps/appBuilders.test
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { APP_RESOURCE_MIME_TYPE, appResource, appTool } from '@/mcp-server/apps/appBuilders.js';
+import { createMockContext } from '@/testing/index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const minimalInput = z.object({ query: z.string().describe('Search query') });
+const minimalOutput = z.object({ result: z.string().describe('Result') });
+
+// ---------------------------------------------------------------------------
+// appTool()
+// ---------------------------------------------------------------------------
+
+describe('appTool()', () => {
+  it('sets name from first argument', () => {
+    const def = appTool('my_app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test app tool',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.name).toBe('my_app_tool');
+  });
+
+  it('populates _meta.ui.resourceUri', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def._meta?.ui).toEqual({ resourceUri: 'ui://my-app/app.html' });
+  });
+
+  it('populates the backwards-compat "ui/resourceUri" key', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def._meta?.['ui/resourceUri']).toBe('ui://my-app/app.html');
+  });
+
+  it('merges extraMeta into _meta', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      extraMeta: { vendor: { featureFlag: true } },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def._meta?.vendor).toEqual({ featureFlag: true });
+    // ui and compat key still present
+    expect(def._meta?.ui).toEqual({ resourceUri: 'ui://my-app/app.html' });
+    expect(def._meta?.['ui/resourceUri']).toBe('ui://my-app/app.html');
+  });
+
+  it('ui key takes precedence over extraMeta.ui (auto-populated wins)', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      extraMeta: { ui: { resourceUri: 'ui://SHOULD-NOT-WIN/app.html' } },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    // Auto-populated value wins because it's spread after extraMeta
+    expect(def._meta?.ui).toEqual({ resourceUri: 'ui://my-app/app.html' });
+  });
+
+  it('preserves description', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Interactive widget',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.description).toBe('Interactive widget');
+  });
+
+  it('preserves input and output schemas', () => {
+    const input = z.object({ x: z.number().describe('X value') });
+    const output = z.object({ doubled: z.number().describe('Doubled') });
+
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input,
+      output,
+      handler: (i) => ({ doubled: i.x * 2 }),
+    });
+
+    expect(def.input).toBe(input);
+    expect(def.output).toBe(output);
+    const parsed = def.input.parse({ x: 5 });
+    expect(parsed.x).toBe(5);
+  });
+
+  it('preserves handler and it works', async () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: z.object({ msg: z.string().describe('Message') }),
+      output: z.object({ echo: z.string().describe('Echo') }),
+      handler: (input) => ({ echo: `Echo: ${input.msg}` }),
+    });
+
+    const ctx = createMockContext();
+    const result = await def.handler(def.input.parse({ msg: 'hello' }), ctx);
+    expect(result.echo).toBe('Echo: hello');
+  });
+
+  it('preserves annotations', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      annotations: { readOnlyHint: true, openWorldHint: false },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.annotations?.readOnlyHint).toBe(true);
+    expect(def.annotations?.openWorldHint).toBe(false);
+  });
+
+  it('preserves auth scopes', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      auth: ['tool:app_tool:read'],
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.auth).toEqual(['tool:app_tool:read']);
+  });
+
+  it('preserves format function', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'data' }),
+      format: (r) => [
+        { type: 'text', text: JSON.stringify(r) },
+        { type: 'text', text: `Result: ${r.result}` },
+      ],
+    });
+
+    const blocks = def.format!({ result: 'data' });
+    expect(blocks).toHaveLength(2);
+    expect(JSON.parse((blocks[0] as { text: string }).text)).toEqual({ result: 'data' });
+    expect((blocks[1] as { text: string }).text).toBe('Result: data');
+  });
+
+  it('preserves title', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      title: 'My App Tool',
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.title).toBe('My App Tool');
+  });
+
+  it('preserves task flag', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      task: true,
+      input: minimalInput,
+      output: minimalOutput,
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect(def.task).toBe(true);
+  });
+
+  it('does not leak resourceUri or extraMeta as top-level fields', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      extraMeta: { custom: true },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    expect((def as unknown as Record<string, unknown>).resourceUri).toBeUndefined();
+    expect((def as unknown as Record<string, unknown>).extraMeta).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appResource()
+// ---------------------------------------------------------------------------
+
+describe('appResource()', () => {
+  it('sets uriTemplate from first argument', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.uriTemplate).toBe('ui://my-app/app.html');
+  });
+
+  it('defaults mimeType to APP_RESOURCE_MIME_TYPE', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.mimeType).toBe(APP_RESOURCE_MIME_TYPE);
+    expect(def.mimeType).toBe('text/html;profile=mcp-app');
+  });
+
+  it('allows overriding mimeType', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      mimeType: 'text/html',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.mimeType).toBe('text/html');
+  });
+
+  it('defaults annotations.audience to ["user"]', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.annotations?.audience).toEqual(['user']);
+  });
+
+  it('allows overriding annotations.audience', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      annotations: { audience: ['user', 'assistant'] },
+      handler: () => '<html></html>',
+    });
+
+    expect(def.annotations?.audience).toEqual(['user', 'assistant']);
+  });
+
+  it('preserves additional annotation fields alongside default audience', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      annotations: { priority: 0.9 },
+      handler: () => '<html></html>',
+    });
+
+    // audience default applies, priority is preserved
+    expect(def.annotations?.audience).toEqual(['user']);
+    expect(def.annotations?.priority).toBe(0.9);
+  });
+
+  it('preserves description', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'Interactive UI for my app tool.',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.description).toBe('Interactive UI for my app tool.');
+  });
+
+  it('preserves name', () => {
+    const def = appResource('ui://my-app/app.html', {
+      name: 'my-app-ui',
+      description: 'App UI',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.name).toBe('my-app-ui');
+  });
+
+  it('preserves title', () => {
+    const def = appResource('ui://my-app/app.html', {
+      title: 'My App UI',
+      description: 'App UI',
+      handler: () => '<html></html>',
+    });
+
+    expect(def.title).toBe('My App UI');
+  });
+
+  it('preserves params schema', () => {
+    const params = z.object({ theme: z.string().describe('Theme name') });
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      params,
+      handler: () => '<html></html>',
+    });
+
+    expect(def.params).toBe(params);
+    expect(def.params!.parse({ theme: 'dark' })).toEqual({ theme: 'dark' });
+  });
+
+  it('preserves auth scopes', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      auth: ['resource:my-app-ui:read'],
+      handler: () => '<html></html>',
+    });
+
+    expect(def.auth).toEqual(['resource:my-app-ui:read']);
+  });
+
+  it('preserves handler and it works', () => {
+    const html = '<!DOCTYPE html><html><body>Hello</body></html>';
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: () => html,
+    });
+
+    const result = def.handler({}, {} as any);
+    expect(result).toBe(html);
+  });
+
+  it('preserves async handler', async () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: async () => '<html>async</html>',
+    });
+
+    const result = await def.handler({}, {} as any);
+    expect(result).toBe('<html>async</html>');
+  });
+
+  it('preserves list function', async () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      handler: () => '<html></html>',
+      list: () => ({
+        resources: [{ uri: 'ui://my-app/app.html', name: 'My App' }],
+      }),
+    });
+
+    const listing = await def.list!({} as any);
+    expect(listing.resources).toHaveLength(1);
+    expect(listing.resources[0]!.uri).toBe('ui://my-app/app.html');
+  });
+
+  it('preserves _meta', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      _meta: {
+        ui: {
+          csp: { resource_domains: ['https://cdn.example.com'] },
+          permissions: ['microphone'],
+        },
+      },
+      handler: () => '<html></html>',
+    });
+
+    expect(def._meta?.ui).toEqual({
+      csp: { resource_domains: ['https://cdn.example.com'] },
+      permissions: ['microphone'],
+    });
+  });
+
+  it('does not leak mimeType override into a second field', () => {
+    const def = appResource('ui://my-app/app.html', {
+      description: 'App UI',
+      mimeType: 'text/html',
+      handler: () => '<html></html>',
+    });
+
+    // Only one mimeType field, no duplication
+    expect(def.mimeType).toBe('text/html');
+    const keys = Object.keys(def).filter((k) => k === 'mimeType');
+    expect(keys).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// APP_RESOURCE_MIME_TYPE constant
+// ---------------------------------------------------------------------------
+
+describe('APP_RESOURCE_MIME_TYPE', () => {
+  it('matches the ext-apps spec value', () => {
+    expect(APP_RESOURCE_MIME_TYPE).toBe('text/html;profile=mcp-app');
+  });
+});

--- a/tests/unit/mcp-server/apps/appBuilders.test.ts
+++ b/tests/unit/mcp-server/apps/appBuilders.test.ts
@@ -75,7 +75,7 @@ describe('appTool()', () => {
     expect(def._meta?.['ui/resourceUri']).toBe('ui://my-app/app.html');
   });
 
-  it('ui key takes precedence over extraMeta.ui (auto-populated wins)', () => {
+  it('auto-populated resourceUri wins over extraMeta.ui.resourceUri', () => {
     const def = appTool('app_tool', {
       resourceUri: 'ui://my-app/app.html',
       description: 'Test',
@@ -85,8 +85,41 @@ describe('appTool()', () => {
       handler: () => ({ result: 'ok' }),
     });
 
-    // Auto-populated value wins because it's spread after extraMeta
-    expect(def._meta?.ui).toEqual({ resourceUri: 'ui://my-app/app.html' });
+    // Auto-populated value wins because it's spread after extraMeta.ui
+    expect((def._meta?.ui as Record<string, unknown>).resourceUri).toBe('ui://my-app/app.html');
+  });
+
+  it('merges extraMeta.ui fields (visibility) with resourceUri', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      extraMeta: {
+        ui: {
+          visibility: ['app'],
+        },
+      },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    const ui = def._meta?.ui as Record<string, unknown>;
+    expect(ui.resourceUri).toBe('ui://my-app/app.html');
+    expect(ui.visibility).toEqual(['app']);
+  });
+
+  it('handles extraMeta.ui as non-object gracefully', () => {
+    const def = appTool('app_tool', {
+      resourceUri: 'ui://my-app/app.html',
+      description: 'Test',
+      input: minimalInput,
+      output: minimalOutput,
+      extraMeta: { ui: 'not-an-object' },
+      handler: () => ({ result: 'ok' }),
+    });
+
+    // Non-object ui is ignored, resourceUri still set
+    expect((def._meta?.ui as Record<string, unknown>).resourceUri).toBe('ui://my-app/app.html');
   });
 
   it('preserves description', () => {
@@ -376,16 +409,16 @@ describe('appResource()', () => {
       description: 'App UI',
       _meta: {
         ui: {
-          csp: { resource_domains: ['https://cdn.example.com'] },
-          permissions: ['microphone'],
+          csp: { resourceDomains: ['https://cdn.example.com'] },
+          permissions: { microphone: {} },
         },
       },
       handler: () => '<html></html>',
     });
 
     expect(def._meta?.ui).toEqual({
-      csp: { resource_domains: ['https://cdn.example.com'] },
-      permissions: ['microphone'],
+      csp: { resourceDomains: ['https://cdn.example.com'] },
+      permissions: { microphone: {} },
     });
   });
 

--- a/tests/unit/mcp-server/resources/resource-registration.test.ts
+++ b/tests/unit/mcp-server/resources/resource-registration.test.ts
@@ -183,6 +183,45 @@ describe('ResourceRegistry', () => {
       expect(call[2].annotations).toEqual({ audience: ['user'], priority: 0.8 });
     });
 
+    it('should pass _meta to server.resource', async () => {
+      const testResource = resource('ui://app/app.html', {
+        name: 'app-ui',
+        description: 'App UI resource',
+        mimeType: 'text/html;profile=mcp-app',
+        handler: () => '<html></html>',
+        _meta: {
+          ui: {
+            csp: { resource_domains: ['https://cdn.example.com'] },
+            permissions: ['microphone'],
+          },
+        },
+      });
+
+      const registry = new ResourceRegistry([testResource], services);
+      await registry.registerAll(mockServer);
+
+      const call = mockServer.resource.mock.calls[0];
+      expect(call[2]._meta).toEqual({
+        ui: {
+          csp: { resource_domains: ['https://cdn.example.com'] },
+          permissions: ['microphone'],
+        },
+      });
+    });
+
+    it('should not include _meta when not provided', async () => {
+      const testResource = resource('plain://{id}', {
+        description: 'No meta',
+        handler: () => ({}),
+      });
+
+      const registry = new ResourceRegistry([testResource], services);
+      await registry.registerAll(mockServer);
+
+      const call = mockServer.resource.mock.calls[0];
+      expect(call[2]._meta).toBeUndefined();
+    });
+
     it('should pass examples to server.resource', async () => {
       const testResource = resource('ex://{id}', {
         description: 'With examples',

--- a/tests/unit/mcp-server/tools/tool-registration.test.ts
+++ b/tests/unit/mcp-server/tools/tool-registration.test.ts
@@ -352,6 +352,68 @@ describe('ToolRegistry', () => {
     });
   });
 
+  describe('_meta Passthrough', () => {
+    it('should pass _meta to server.registerTool for standard tools', async () => {
+      const testTool = tool('app_tool', {
+        description: 'App tool with _meta',
+        input: z.object({}),
+        output: z.object({}),
+        handler: () => ({}),
+        _meta: {
+          ui: { resourceUri: 'ui://my-app/app.html' },
+          'ui/resourceUri': 'ui://my-app/app.html',
+        },
+      });
+
+      const registry = new ToolRegistry([testTool], services);
+      await registry.registerAll(mockServer);
+
+      const call = mockServer.registerTool.mock.calls[0];
+      expect(call[1]._meta).toEqual({
+        ui: { resourceUri: 'ui://my-app/app.html' },
+        'ui/resourceUri': 'ui://my-app/app.html',
+      });
+    });
+
+    it('should not include _meta when not provided', async () => {
+      const testTool = tool('plain_tool', {
+        description: 'Tool without _meta',
+        input: z.object({}),
+        output: z.object({}),
+        handler: () => ({}),
+      });
+
+      const registry = new ToolRegistry([testTool], services);
+      await registry.registerAll(mockServer);
+
+      const call = mockServer.registerTool.mock.calls[0];
+      expect(call[1]._meta).toBeUndefined();
+    });
+
+    it('should pass _meta to registerToolTask for auto-task tools', async () => {
+      const taskTool = tool('task_app_tool', {
+        description: 'Task app tool',
+        input: z.object({}),
+        output: z.object({}),
+        task: true,
+        handler: async () => ({}),
+        _meta: {
+          ui: { resourceUri: 'ui://task-app/app.html' },
+          'ui/resourceUri': 'ui://task-app/app.html',
+        },
+      });
+
+      const registry = new ToolRegistry([taskTool], services);
+      await registry.registerAll(mockServer);
+
+      const call = mockServer.experimental.tasks.registerToolTask.mock.calls[0];
+      expect(call[1]._meta).toEqual({
+        ui: { resourceUri: 'ui://task-app/app.html' },
+        'ui/resourceUri': 'ui://task-app/app.html',
+      });
+    });
+  });
+
   describe('Complex Tools', () => {
     it('should handle tool with complex nested schemas', async () => {
       const complexTool = tool('complex_tool', {


### PR DESCRIPTION
## Summary

MCP Apps integration for v0.3.0 — convenience builders, `_meta` passthrough, linter validation, template examples, and comprehensive test coverage.

### New Features

- **`appTool()` and `appResource()` builders** — Wrap `tool()` and `resource()` with MCP Apps defaults: auto-populated `_meta.ui.resourceUri`, compat key (`ui/resourceUri`), correct MIME type (`text/html;profile=mcp-app`), and `audience: ['user']` annotation. Exported from main entry point alongside `APP_RESOURCE_MIME_TYPE` constant.

- **`_meta` passthrough** — `ResourceDefinition` and `TaskToolDefinition` interfaces accept `_meta`. Tool and resource registration passes it through to the SDK.

- **Linter rules for MCP Apps** — `_meta.ui` field validation (`meta-ui-type`, `meta-ui-resource-uri-required`, `meta-ui-resource-uri-scheme`) and cross-definition `lintAppToolResourcePairing()` that verifies every app tool's `resourceUri` has a matching registered resource.

- **Template echo app** — `echo-app.app-tool.ts` and `echo-app-ui.app-resource.ts` demonstrate the full MCP Apps pattern for scaffolded consumer servers.

- **`add-app-tool` skill** — Step-by-step scaffolding guide for MCP App tool + UI resource pairs.

- **Updated `design-mcp-server` skill** — App Tool added as a primitive in classification table, `add-app-tool` in post-design workflow, MCP Apps checklist item.

### Tests

- **1,463 lines of new tests** across 8 test files:
  - Unit: `appBuilders.test.ts` (414), `tool-rules.test.ts` (285), `validate.test.ts` (+195), `resource-registration.test.ts` (+39), `tool-registration.test.ts` (+62)
  - Integration: `mcp-apps.int.test.ts` (258)
  - Smoke: `template-echo-app.app-tool.test.ts` (115), `echo-app-ui.app-resource.test.ts` (95)

### Dependencies

dotenv 17.4.0→17.4.1, hono 4.12.10→4.12.11, @cloudflare/workers-types, msw ^2.13.0, vite 8.0.5, biome schema 2.4.10

### Verification

- `bun run devcheck` — all checks pass
- `bun run test` — 2190 tests pass (133 files)